### PR TITLE
Update to the last rust.

### DIFF
--- a/src/glfw/extfn.rs
+++ b/src/glfw/extfn.rs
@@ -28,7 +28,7 @@ static error_fun_tls_key: local_data::Key<ErrorFun> = &local_data::Key;
 
 pub extern "C" fn error_callback(error: c_int, description: *c_char) {
     do local_data::get(error_fun_tls_key) |data| {
-        do data.map |&ref cb| {
+        do data.as_ref().map |&ref cb| {
             unsafe { (**cb)(cast::transmute(error as int), str::raw::from_c_str(description)) }
         };
     }
@@ -43,7 +43,7 @@ static monitor_fun_tls_key: local_data::Key<MonitorFun> = &local_data::Key;
 
 pub extern "C" fn monitor_callback(monitor: *ffi::GLFWmonitor, event: c_int) {
     do local_data::get(monitor_fun_tls_key) |data| {
-        do data.map |&ref cb| {
+        do data.as_ref().map |&ref cb| {
             unsafe { (**cb)(&Monitor { ptr: monitor }, cast::transmute(event as int)) }
         };
     }
@@ -65,7 +65,7 @@ macro_rules! window_callback(
          pub extern "C" fn $name(window: *ffi::GLFWwindow) {
             unsafe {
                 let window = Window { ptr: window, is_shared: false };
-                window.get_fns().$field.map(|cb| (*cb)(&window));
+                window.get_fns().$field.as_ref().map(|cb| (*cb)(&window));
                 cast::forget(window);
             }
          }
@@ -74,7 +74,7 @@ macro_rules! window_callback(
          pub extern "C" fn $name(window: *ffi::GLFWwindow $(, $ext_arg: $ext_arg_ty)*) {
             unsafe {
                 let window = Window { ptr: window, is_shared: false };
-                window.get_fns().$field.map(|cb| (*cb)(&window $(, $arg_conv)*));
+                window.get_fns().$field.as_ref().map(|cb| (*cb)(&window $(, $arg_conv)*));
                 cast::forget(window);
             }
          }

--- a/src/glfw/lib.rs
+++ b/src/glfw/lib.rs
@@ -350,7 +350,7 @@ impl Monitor {
             ffi::glfwGetPrimaryMonitor()
              .to_option()
              .map_default(Err(()),
-                |&ptr| Ok(Monitor { ptr: ptr }))
+                |ptr| Ok(Monitor { ptr: ptr }))
         }
     }
 
@@ -414,7 +414,7 @@ impl Monitor {
     #[fixed_stack_segment] #[inline(never)]
     pub fn get_video_mode(&self) -> Option<VidMode> {
         unsafe {
-            ffi::glfwGetVideoMode(self.ptr).to_option().map(|&v| VidMode::from_glfw_vid_mode(v))
+            ffi::glfwGetVideoMode(self.ptr).to_option().map(|v| VidMode::from_glfw_vid_mode(v))
         }
     }
 
@@ -833,7 +833,7 @@ impl Window {
                     match share { Some(w) => w.ptr, None => ptr::null() }
                 )
             }.to_option().map_default(Err(()),
-                |&ptr| {
+                |ptr| {
                     let windowfns = WindowFns::new();
                     ffi::glfwSetWindowUserPointer(ptr, cast::transmute(~windowfns));
                     let window = ~Window {


### PR DESCRIPTION
Option `map` method does not give a reference to the wrapped element any more.
It should be replaced by `as_ref().map`.
