### PR TITLE
Don't need link_args feature.

### DIFF
--- a/src/examples/callbacks/main.rs
+++ b/src/examples/callbacks/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 use std::libc;

--- a/src/examples/clipboard/main.rs
+++ b/src/examples/clipboard/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 use std::libc;

--- a/src/examples/cursor/main.rs
+++ b/src/examples/cursor/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 use std::libc;

--- a/src/examples/defaults/main.rs
+++ b/src/examples/defaults/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 #[link(name="glfw")]
@@ -81,14 +79,12 @@ impl glfw::ErrorCallback for ErrorContext {
 mod gl {
     use std::libc;
 
-    #[nolink]
-    #[link_args="-framework OpenGL"]
     #[cfg(target_os = "macos")]
+    #[link(name="OpenGL", kind="framework")]
     extern { }
 
-    #[nolink]
-    #[link_args="-lGL"]
     #[cfg(target_os = "linux")]
+    #[link(name="GL")]
     extern { }
 
     pub type GLenum = libc::c_uint;

--- a/src/examples/manual-init/main.rs
+++ b/src/examples/manual-init/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 use std::libc;

--- a/src/examples/modes/main.rs
+++ b/src/examples/modes/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 #[link(name="glfw")]

--- a/src/examples/title/main.rs
+++ b/src/examples/title/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 use std::libc;

--- a/src/examples/version/main.rs
+++ b/src/examples/version/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 #[link(name="glfw")]

--- a/src/examples/window/main.rs
+++ b/src/examples/window/main.rs
@@ -13,8 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[feature(link_args)];
-
 extern mod glfw;
 
 use std::libc;

--- a/src/glfw/lib.rs
+++ b/src/glfw/lib.rs
@@ -24,7 +24,6 @@
 
 #[feature(globs)];
 #[feature(macro_rules)];
-#[feature(link_args)];
 
 // TODO: Document differences between GLFW and glfw-rs
 


### PR DESCRIPTION
Get rid of all the `#[feature(link_args)];` and one `#[link_args]` I missed in an example.
