### PR TITLE
A fix to the readme example so it will compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn main() {
 
 struct ErrorContext;
 impl glfw::ErrorCallback for ErrorContext {
-    fn call(_: glfw::Error, description: ~str) {
+    fn call(&self, _: glfw::Error, description: ~str) {
         println!("GLFW Error: {:s}", description);
     }
 }


### PR DESCRIPTION
The function call for the trait glfw::ErrorCallback requires a mutable self argument.
