### PR TITLE
Change from link metadata to pkgid.

### DIFF
--- a/src/glfw/lib.rs
+++ b/src/glfw/lib.rs
@@ -13,14 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[link(name = "glfw",
-       package_id = "glfw",
-       vers = "0.1",
-       author = "Brendan Zabarauskas",
-       url = "https://github.com/bjz/glfw3-rs")];
-
+#[pkgid = "github.com/bjz/glfw-rs/src/glfw#0.1"];
 #[comment = "Bindings and wrapper functions for glfw3."];
-#[crate_type = "lib"];
 
 #[feature(globs)];
 #[feature(macro_rules)];


### PR DESCRIPTION
Note that the path is slightly incorrect unless we want to have the link name
be glfw-rs or until rustc is updated to support setting the link name
independently of the path.
