### PR TITLE
Fix link arguments on Windows

### DIFF
--- a/src/examples/callbacks/main.rs
+++ b/src/examples/callbacks/main.rs
@@ -17,9 +17,6 @@ extern mod glfw;
 
 use std::libc;
 
-#[link(name="glfw")]
-extern {}
-
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     std::rt::start_on_main_thread(argc, argv, main)

--- a/src/examples/clipboard/main.rs
+++ b/src/examples/clipboard/main.rs
@@ -17,9 +17,6 @@ extern mod glfw;
 
 use std::libc;
 
-#[link(name="glfw")]
-extern {}
-
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     std::rt::start_on_main_thread(argc, argv, main)

--- a/src/examples/cursor/main.rs
+++ b/src/examples/cursor/main.rs
@@ -17,9 +17,6 @@ extern mod glfw;
 
 use std::libc;
 
-#[link(name="glfw")]
-extern {}
-
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     std::rt::start_on_main_thread(argc, argv, main)

--- a/src/examples/defaults/main.rs
+++ b/src/examples/defaults/main.rs
@@ -15,9 +15,6 @@
 
 extern mod glfw;
 
-#[link(name="glfw")]
-extern {}
-
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     std::rt::start_on_main_thread(argc, argv, main)

--- a/src/examples/manual-init/main.rs
+++ b/src/examples/manual-init/main.rs
@@ -18,9 +18,6 @@ extern mod glfw;
 use std::libc;
 use std::unstable::finally::Finally;
 
-#[link(name="glfw")]
-extern {}
-
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     // GLFW must run on the main platform thread

--- a/src/examples/modes/main.rs
+++ b/src/examples/modes/main.rs
@@ -15,9 +15,6 @@
 
 extern mod glfw;
 
-#[link(name="glfw")]
-extern {}
-
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     std::rt::start_on_main_thread(argc, argv, main)

--- a/src/examples/title/main.rs
+++ b/src/examples/title/main.rs
@@ -17,9 +17,6 @@ extern mod glfw;
 
 use std::libc;
 
-#[link(name="glfw")]
-extern {}
-
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     std::rt::start_on_main_thread(argc, argv, main)

--- a/src/examples/version/main.rs
+++ b/src/examples/version/main.rs
@@ -15,9 +15,6 @@
 
 extern mod glfw;
 
-#[link(name="glfw")]
-extern {}
-
 fn main() {
     println(glfw::get_version().to_str());
     println!("GLFW version: {:s}", glfw::get_version_string());

--- a/src/examples/window/main.rs
+++ b/src/examples/window/main.rs
@@ -17,9 +17,6 @@ extern mod glfw;
 
 use std::libc;
 
-#[link(name="glfw")]
-extern {}
-
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     std::rt::start_on_main_thread(argc, argv, main)

--- a/src/glfw/ffi.rs
+++ b/src/glfw/ffi.rs
@@ -306,6 +306,8 @@ extern { }
 
 #[cfg(target_os = "win32")]
 #[link(name="glfw3")]
+#[link(name="opengl32")]
+#[link(name="gdi32")]
 extern { }
 
 // C function bindings


### PR DESCRIPTION
This is needed to make the examples compile on Windows.
