### PR TITLE
std::rt::start_on_main_thread is gone !

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,15 @@ GLFW bindings and wrapper for The Rust Programming Language.
 ## Example code
 
 ~~~rust
+extern mod native;
 extern mod glfw;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     // Run GLFW on the main thread
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {
@@ -65,13 +68,12 @@ ln -s /usr/local/lib/libglfw3.dylib /usr/local/lib/libglfw.dylib
 
 ### Building the examples
 ~~~
-rustpkg build examples
+mkdir bin
+rustc --opt-level 3  src/examples/title/main.rs -o bin/title
+rustc --opt-level 3  src/examples/window/main.rs -o bin/window
+etc.
 ~~~
 
-### Building a specific example
-~~~
-rustpkg build examples/callbacks
-~~~
 
 ## FAQ
 

--- a/src/examples/callbacks/main.rs
+++ b/src/examples/callbacks/main.rs
@@ -13,13 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern mod native;
 extern mod glfw;
 
 use std::libc;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {

--- a/src/examples/clipboard/main.rs
+++ b/src/examples/clipboard/main.rs
@@ -13,13 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern mod native;
 extern mod glfw;
 
 use std::libc;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {

--- a/src/examples/cursor/main.rs
+++ b/src/examples/cursor/main.rs
@@ -13,13 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern mod native;
 extern mod glfw;
 
 use std::libc;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {

--- a/src/examples/defaults/main.rs
+++ b/src/examples/defaults/main.rs
@@ -12,12 +12,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
+extern mod native;
 extern mod glfw;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {

--- a/src/examples/manual-init/main.rs
+++ b/src/examples/manual-init/main.rs
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern mod native;
 extern mod glfw;
 
 use std::libc;
@@ -21,7 +22,9 @@ use std::unstable::finally::Finally;
 #[start]
 fn start(argc: int, argv: **u8) -> int {
     // GLFW must run on the main platform thread
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {

--- a/src/examples/modes/main.rs
+++ b/src/examples/modes/main.rs
@@ -13,11 +13,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern mod native;
 extern mod glfw;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {

--- a/src/examples/title/main.rs
+++ b/src/examples/title/main.rs
@@ -13,13 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern mod native;
 extern mod glfw;
 
 use std::libc;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {

--- a/src/examples/window/main.rs
+++ b/src/examples/window/main.rs
@@ -13,13 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+extern mod native;
 extern mod glfw;
 
 use std::libc;
 
 #[start]
 fn start(argc: int, argv: **u8) -> int {
-    std::rt::start_on_main_thread(argc, argv, main)
+    do native::start(argc, argv){
+        main();
+    }
 }
 
 fn main() {


### PR DESCRIPTION
Use libnative and libgreen instead.
Changes in response to pull request #10965 on rust/master
Ref: https://mail.mozilla.org/pipermail/rust-dev/2013-December/007565.html
