### PR TITLE
Remove 'do' syntax from examples and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fn main() {
     glfw::set_error_callback(~ErrorContext);
 
     // Initialize the library
-    do glfw::start {
+    glfw::start(proc() {
         // Create a windowed mode window and its OpenGL context
         let window = glfw::Window::create(300, 300, "Hello this is window", glfw::Windowed)
             .expect("Failed to create GLFW window.");
@@ -52,7 +52,7 @@ fn main() {
             // Poll for and process events
             glfw::poll_events();
         }
-    }
+    });
 }
 
 struct ErrorContext;

--- a/examples/callbacks.rs
+++ b/examples/callbacks.rs
@@ -26,7 +26,7 @@ fn start(argc: int, argv: **u8) -> int {
 fn main() {
     glfw::set_error_callback(~ErrorContext);
 
-    do glfw::start {
+    glfw::start(proc() {
         glfw::window_hint::resizable(true);
 
         let window = glfw::Window::create(800, 600, "Hello, I am a window.", glfw::Windowed)
@@ -56,7 +56,7 @@ fn main() {
         while !window.should_close() {
             glfw::poll_events();
         }
-    }
+    });
 }
 
 struct ErrorContext;

--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -26,7 +26,7 @@ fn start(argc: int, argv: **u8) -> int {
 fn main() {
     glfw::set_error_callback(~ErrorContext);
 
-    do glfw::start {
+    glfw::start(proc() {
         let window = glfw::Window::create(300, 300, "Clipboard Test", glfw::Windowed)
             .expect("Failed to create GLFW window.");
 
@@ -37,7 +37,7 @@ fn main() {
         while !window.should_close() {
             glfw::poll_events();
         }
-    }
+    });
 }
 
 #[cfg(target_os = "macos")]

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -26,7 +26,7 @@ fn start(argc: int, argv: **u8) -> int {
 fn main() {
    glfw::set_error_callback(~ErrorContext);
 
-    do glfw::start {
+    glfw::start(proc() {
         let window = glfw::Window::create(800, 600, "Hello, I am a window.", glfw::Windowed)
             .expect("Failed to create GLFW window.");
 
@@ -39,7 +39,7 @@ fn main() {
         while !window.should_close() {
             glfw::poll_events();
         }
-    }
+    });
 }
 
 struct ErrorContext;

--- a/examples/defaults.rs
+++ b/examples/defaults.rs
@@ -23,7 +23,7 @@ fn start(argc: int, argv: **u8) -> int {
 fn main() {
     glfw::set_error_callback(~ErrorContext);
 
-    do glfw::start {
+    glfw::start(proc() {
         glfw::window_hint::visible(true);
 
         let window = glfw::Window::create(640, 480, "Defaults", glfw::Windowed)
@@ -63,7 +63,7 @@ fn main() {
                 println!("OpenGL {:s}: {}", name, value);
             };
         }
-    }
+    });
 }
 
 struct ErrorContext;

--- a/examples/modes.rs
+++ b/examples/modes.rs
@@ -22,7 +22,7 @@ fn start(argc: int, argv: **u8) -> int {
 }
 
 fn main() {
-    do glfw::start {
+    glfw::start(proc() {
         glfw::Monitor::get_primary().map(|monitor| {
                 println!("{:s}:", monitor.get_name());
                 println!("    {:s}\n", monitor.get_video_mode().unwrap().to_str());
@@ -37,5 +37,5 @@ fn main() {
                 println!("  {:s}", mode.to_str());
             });
         });
-    }
+    });
 }

--- a/examples/title.rs
+++ b/examples/title.rs
@@ -26,7 +26,7 @@ fn start(argc: int, argv: **u8) -> int {
 fn main() {
     glfw::set_error_callback(~ErrorContext);
 
-    do glfw::start {
+    glfw::start(proc() {
         let window = glfw::Window::create(400, 400, "English 日本語 русский язык 官話", glfw::Windowed)
             .expect("Failed to create GLFW window.");
 
@@ -37,7 +37,7 @@ fn main() {
         while !window.should_close() {
             glfw::poll_events();
         }
-    }
+    });
 }
 
 struct ErrorContext;

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -26,7 +26,7 @@ fn start(argc: int, argv: **u8) -> int {
 fn main() {
     glfw::set_error_callback(~ErrorContext);
 
-    do glfw::start {
+    glfw::start(proc() {
         let window = glfw::Window::create(300, 300, "Hello this is window", glfw::Windowed)
             .expect("Failed to create GLFW window.");
 
@@ -36,7 +36,7 @@ fn main() {
         while !window.should_close() {
             glfw::poll_events();
         }
-    }
+    });
 }
 
 struct ErrorContext;


### PR DESCRIPTION
`do` syntax was removed in the latest Rust.

(This is my first pull request so I hope I did everything right)
