### PR TITLE
link-args: include -L options in output

### DIFF
--- a/src/etc/link-args.rs
+++ b/src/etc/link-args.rs
@@ -40,7 +40,7 @@ fn main() {
             e => fail!("Unexpected error when locating locate pkg-config: {}", e.to_str()),
         }
     }).inside(|| {
-        println!("{}", Process::new("pkg-config", [~"--static", ~"--libs-only-l", ~"--libs-only-other", ~"glfw3"], ProcessOptions::new())
+        println!("{}", Process::new("pkg-config", [~"--static", ~"--libs", ~"glfw3"], ProcessOptions::new())
             .expect("Failed to run pkg-config.")
             .output().read_to_str());
     });


### PR DESCRIPTION
If glfw3 is in a non-standard location then the library search path output by `pkg-config --libs` is necessary to link with it.

This is useful for rust-gamedev-kit which installs glfw locally.
