### PR TITLE
std::vec_ng -> std::vec, std::vec -> std::slice

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -36,8 +36,8 @@ use std::fmt;
 use std::libc::*;
 use std::ptr;
 use std::str;
-use std::vec;
-use std::vec_ng::Vec;
+use std::vec::Vec;
+use std::slice;
 use semver::Version;
 
 pub mod ffi;
@@ -355,7 +355,7 @@ impl Monitor {
         unsafe {
             let mut count = 0;
             let ptr = ffi::glfwGetMonitors(&mut count);
-            vec::from_buf(ptr, count as uint).map(|&m| Monitor { ptr: m })
+            slice::from_buf(ptr, count as uint).map(|&m| Monitor { ptr: m })
         }
     }
 
@@ -396,7 +396,7 @@ impl Monitor {
         unsafe {
             let mut count = 0;
             let ptr = ffi::glfwGetVideoModes(self.ptr, &mut count);
-            vec::from_buf(ptr, count as uint).map(VidMode::from_glfw_vid_mode)
+            slice::from_buf(ptr, count as uint).map(VidMode::from_glfw_vid_mode)
         }
     }
 
@@ -417,9 +417,9 @@ impl Monitor {
         unsafe {
             let llramp = *ffi::glfwGetGammaRamp(self.ptr);
             GammaRamp {
-                red:    vec::from_buf(llramp.red,   llramp.size as uint),
-                green:  vec::from_buf(llramp.green, llramp.size as uint),
-                blue:   vec::from_buf(llramp.blue,  llramp.size as uint),
+                red:    slice::from_buf(llramp.red,   llramp.size as uint),
+                green:  slice::from_buf(llramp.green, llramp.size as uint),
+                blue:   slice::from_buf(llramp.blue,  llramp.size as uint),
             }
         }
     }
@@ -1236,7 +1236,7 @@ impl Joystick {
         unsafe {
             let mut count = 0;
             let ptr = ffi::glfwGetJoystickAxes(*self as c_int, &mut count);
-            vec::from_buf(ptr, count as uint).map(|&a| a as f32)
+            slice::from_buf(ptr, count as uint).map(|&a| a as f32)
         }
     }
 
@@ -1245,7 +1245,7 @@ impl Joystick {
         unsafe {
             let mut count = 0;
             let ptr = ffi::glfwGetJoystickButtons(*self as c_int, &mut count);
-            vec::from_buf(ptr, count as uint).map(|&b| b as c_int)
+            slice::from_buf(ptr, count as uint).map(|&b| b as c_int)
         }
     }
 


### PR DESCRIPTION
Update std::vec -> std::slice and std::vec_ng -> std::vec.
See https://github.com/mozilla/rust/pull/12772 and https://github.com/mozilla/rust/pull/13028.
