### PR TITLE
Fixed WindowMode

### DIFF
--- a/src/examples/modes.rs
+++ b/src/examples/modes.rs
@@ -24,7 +24,7 @@ fn start(argc: int, argv: **u8) -> int {
 fn main() {
     let glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
-    glfw.get_primary_monitor(|monitor| {
+    glfw.with_primary_monitor(|monitor| {
         let _ = monitor.map(|monitor| {
             println!("{}:", monitor.get_name());
             println!("    {}\n", monitor.get_video_mode().unwrap());
@@ -33,7 +33,7 @@ fn main() {
 
     println!("Available monitors\n\
               ------------------");
-    glfw.get_connected_monitors(|monitors| {
+    glfw.with_connected_monitors(|monitors| {
         for monitor in monitors.iter() {
             println!("{}:", monitor.get_name());
             for mode in monitor.get_video_modes().iter() {

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -487,7 +487,7 @@ impl Glfw {
     /// the OS X menu bar is located.
     ///
     /// Wrapper for `glfwGetPrimaryMonitor`.
-    pub fn get_primary_monitor<T>(&self, f: |Option<&Monitor>| -> T) -> T {
+    pub fn with_primary_monitor<T>(&self, f: |Option<&Monitor>| -> T) -> T {
         match unsafe { ffi::glfwGetPrimaryMonitor() } {
             ptr if ptr.is_null() => f(None),
             ptr => f(Some(&Monitor {
@@ -503,7 +503,7 @@ impl Glfw {
     /// provided.
     ///
     /// Wrapper for `glfwGetMonitors`.
-    pub fn get_connected_monitors<T>(&self, f: |&[Monitor]| -> T) -> T {
+    pub fn with_connected_monitors<T>(&self, f: |&[Monitor]| -> T) -> T {
         unsafe {
             let mut count = 0;
             let ptr = ffi::glfwGetMonitors(&mut count);
@@ -1222,7 +1222,7 @@ impl Window {
     /// Returns whether the window is fullscreen or windowed.
     ///
     /// Wrapper for `glfwGetWindowMonitor`.
-    pub fn get_window_mode<T>(&self, f: |WindowMode| -> T) -> T {
+    pub fn with_window_mode<T>(&self, f: |WindowMode| -> T) -> T {
         let ptr = unsafe { ffi::glfwGetWindowMonitor(self.ptr) };
         if ptr.is_null() {
             f(Windowed)


### PR DESCRIPTION
- Made FullScreen wrap a borrowed Monitor.
- Removed from_ptr
- Changed ‘get_window_mode’ to take a closure.

Code example to get full screen:

```
          let glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
          let (window, events) = glfw.with_primary_monitor(|m| {
              glfw.create_window(width, height, title, 
                  glfw::FullScreen(m.unwrap()))
                      .expect("Failed to create GLFW window.")
          });
```
