### PR TITLE
Update for rename of functions from str to string

### DIFF
--- a/src/examples/defaults.rs
+++ b/src/examples/defaults.rs
@@ -36,7 +36,7 @@ fn main() {
     let (width, height) = window.get_size();
     println!("window size: ({}, {})", width, height);
 
-    println!("Context version: {:s}",         window.get_context_version().to_str());
+    println!("Context version: {:s}",         window.get_context_version().to_string());
     println!("OpenGL forward compatible: {}", window.is_opengl_forward_compat());
     println!("OpenGL debug context: {}",      window.is_opengl_debug_context());
     println!("OpenGL profile: {}",            window.get_opengl_profile());

--- a/src/examples/version.rs
+++ b/src/examples/version.rs
@@ -16,6 +16,6 @@
 extern crate glfw;
 
 fn main() {
-    println!("{:s}", glfw::get_version().to_str());
+    println!("{:s}", glfw::get_version().to_string());
     println!("GLFW version: {:s}", glfw::get_version_string());
 }


### PR DESCRIPTION
This fixes it so things work again, at least for the latest nightly.
