### PR TITLE
Unconst all the FFI calls.

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -251,29 +251,29 @@ pub static DISCONNECTED                 : c_int = 0x00040002;
 pub type GLFWglproc             = *const c_void;
 
 pub type GLFWerrorfun           = extern "C" fn(c_int, *const c_char);
-pub type GLFWwindowposfun       = extern "C" fn(*const GLFWwindow, c_int, c_int);
-pub type GLFWwindowsizefun      = extern "C" fn(*const GLFWwindow, c_int, c_int);
-pub type GLFWwindowclosefun     = extern "C" fn(*const GLFWwindow);
-pub type GLFWwindowrefreshfun   = extern "C" fn(*const GLFWwindow);
-pub type GLFWwindowfocusfun     = extern "C" fn(*const GLFWwindow, c_int);
-pub type GLFWwindowiconifyfun   = extern "C" fn(*const GLFWwindow, c_int);
-pub type GLFWframebuffersizefun = extern "C" fn(*const GLFWwindow, c_int, c_int);
-pub type GLFWmousebuttonfun     = extern "C" fn(*const GLFWwindow, c_int, c_int, c_int);
-pub type GLFWcursorposfun       = extern "C" fn(*const GLFWwindow, c_double, c_double);
-pub type GLFWcursorenterfun     = extern "C" fn(*const GLFWwindow, c_int);
-pub type GLFWscrollfun          = extern "C" fn(*const GLFWwindow, c_double, c_double);
-pub type GLFWkeyfun             = extern "C" fn(*const GLFWwindow, c_int, c_int, c_int, c_int);
-pub type GLFWcharfun            = extern "C" fn(*const GLFWwindow, c_uint);
-pub type GLFWmonitorfun         = extern "C" fn(*const GLFWmonitor, c_int);
+pub type GLFWwindowposfun       = extern "C" fn(*mut GLFWwindow, c_int, c_int);
+pub type GLFWwindowsizefun      = extern "C" fn(*mut GLFWwindow, c_int, c_int);
+pub type GLFWwindowclosefun     = extern "C" fn(*mut GLFWwindow);
+pub type GLFWwindowrefreshfun   = extern "C" fn(*mut GLFWwindow);
+pub type GLFWwindowfocusfun     = extern "C" fn(*mut GLFWwindow, c_int);
+pub type GLFWwindowiconifyfun   = extern "C" fn(*mut GLFWwindow, c_int);
+pub type GLFWframebuffersizefun = extern "C" fn(*mut GLFWwindow, c_int, c_int);
+pub type GLFWmousebuttonfun     = extern "C" fn(*mut GLFWwindow, c_int, c_int, c_int);
+pub type GLFWcursorposfun       = extern "C" fn(*mut GLFWwindow, c_double, c_double);
+pub type GLFWcursorenterfun     = extern "C" fn(*mut GLFWwindow, c_int);
+pub type GLFWscrollfun          = extern "C" fn(*mut GLFWwindow, c_double, c_double);
+pub type GLFWkeyfun             = extern "C" fn(*mut GLFWwindow, c_int, c_int, c_int, c_int);
+pub type GLFWcharfun            = extern "C" fn(*mut GLFWwindow, c_uint);
+pub type GLFWmonitorfun         = extern "C" fn(*mut GLFWmonitor, c_int);
 
 pub enum GLFWmonitor {}
 
 pub enum GLFWwindow {}
 
 pub struct GLFWgammaramp {
-    pub red:    *const c_ushort,
-    pub green:  *const c_ushort,
-    pub blue:   *const c_ushort,
+    pub red:    *mut c_ushort,
+    pub green:  *mut c_ushort,
+    pub blue:   *mut c_ushort,
     pub size:   c_uint,
 }
 
@@ -296,89 +296,89 @@ extern "C" {
 
     pub fn glfwSetErrorCallback(cbfun: Option<GLFWerrorfun>) -> Option<GLFWerrorfun>;
 
-    pub fn glfwGetMonitors(count: *mut c_int) -> *const *const GLFWmonitor;
-    pub fn glfwGetPrimaryMonitor() -> *const GLFWmonitor;
-    pub fn glfwGetMonitorPos(monitor: *const GLFWmonitor, xpos: *mut c_int, ypos: *mut c_int);
-    pub fn glfwGetMonitorPhysicalSize(monitor: *const GLFWmonitor, width: *mut c_int, height: *mut c_int);
-    pub fn glfwGetMonitorName(monitor: *const GLFWmonitor) -> *const c_char;
+    pub fn glfwGetMonitors(count: *mut c_int) -> *mut *mut GLFWmonitor;
+    pub fn glfwGetPrimaryMonitor() -> *mut GLFWmonitor;
+    pub fn glfwGetMonitorPos(monitor: *mut GLFWmonitor, xpos: *mut c_int, ypos: *mut c_int);
+    pub fn glfwGetMonitorPhysicalSize(monitor: *mut GLFWmonitor, width: *mut c_int, height: *mut c_int);
+    pub fn glfwGetMonitorName(monitor: *mut GLFWmonitor) -> *const c_char;
     pub fn glfwSetMonitorCallback(cbfun: Option<GLFWmonitorfun>) -> Option<GLFWmonitorfun>;
-    pub fn glfwGetVideoModes(monitor: *const GLFWmonitor, count: *mut c_int) -> *const GLFWvidmode;
-    pub fn glfwGetVideoMode(monitor: *const GLFWmonitor) -> *const GLFWvidmode;
-    pub fn glfwSetGamma(monitor: *const GLFWmonitor, gamma: c_float);
-    pub fn glfwGetGammaRamp(monitor: *const GLFWmonitor) -> *const GLFWgammaramp;
-    pub fn glfwSetGammaRamp(monitor: *const GLFWmonitor, ramp: *const GLFWgammaramp);
+    pub fn glfwGetVideoModes(monitor: *mut GLFWmonitor, count: *mut c_int) -> *const GLFWvidmode;
+    pub fn glfwGetVideoMode(monitor: *mut GLFWmonitor) -> *const GLFWvidmode;
+    pub fn glfwSetGamma(monitor: *mut GLFWmonitor, gamma: c_float);
+    pub fn glfwGetGammaRamp(monitor: *mut GLFWmonitor) -> *const GLFWgammaramp;
+    pub fn glfwSetGammaRamp(monitor: *mut GLFWmonitor, ramp: *const GLFWgammaramp);
 
     pub fn glfwDefaultWindowHints();
     pub fn glfwWindowHint(target: c_int, hint: c_int);
-    pub fn glfwCreateWindow(width: c_int, height: c_int, title: *const c_char, monitor: *const GLFWmonitor, share: *const GLFWwindow) -> *const GLFWwindow;
-    pub fn glfwDestroyWindow(window: *const GLFWwindow);
-    pub fn glfwWindowShouldClose(window: *const GLFWwindow) -> c_int;
-    pub fn glfwSetWindowShouldClose(window: *const GLFWwindow, value: c_int);
-    pub fn glfwSetWindowTitle(window: *const GLFWwindow, title: *const c_char);
-    pub fn glfwGetWindowPos(window: *const GLFWwindow, xpos: *mut c_int, ypos: *mut c_int);
-    pub fn glfwSetWindowPos(window: *const GLFWwindow, xpos: c_int, ypos: c_int);
-    pub fn glfwGetWindowSize(window: *const GLFWwindow, width: *mut c_int, height: *mut c_int);
-    pub fn glfwSetWindowSize(window: *const GLFWwindow, width: c_int, height: c_int);
-    pub fn glfwGetFramebufferSize(window: *const GLFWwindow, width: *mut c_int, height: *mut c_int);
-    pub fn glfwIconifyWindow(window: *const GLFWwindow);
-    pub fn glfwRestoreWindow(window: *const GLFWwindow);
-    pub fn glfwShowWindow(window: *const GLFWwindow);
-    pub fn glfwHideWindow(window: *const GLFWwindow);
-    pub fn glfwGetWindowMonitor(window: *const GLFWwindow) -> *const GLFWmonitor;
-    pub fn glfwGetWindowAttrib(window: *const GLFWwindow, attrib: c_int) -> c_int;
-    pub fn glfwSetWindowUserPointer(window: *const GLFWwindow, pointer: *const c_void);
-    pub fn glfwGetWindowUserPointer(window: *const GLFWwindow) -> *const c_void;
-    pub fn glfwSetWindowPosCallback(window: *const GLFWwindow, cbfun: Option<GLFWwindowposfun>) -> Option<GLFWwindowposfun>;
-    pub fn glfwSetWindowSizeCallback(window: *const GLFWwindow, cbfun: Option<GLFWwindowsizefun>) -> Option<GLFWwindowsizefun>;
-    pub fn glfwSetWindowCloseCallback(window: *const GLFWwindow, cbfun: Option<GLFWwindowclosefun>) -> Option<GLFWwindowclosefun>;
-    pub fn glfwSetWindowRefreshCallback(window: *const GLFWwindow, cbfun: Option<GLFWwindowrefreshfun>) -> Option<GLFWwindowrefreshfun>;
-    pub fn glfwSetWindowFocusCallback(window: *const GLFWwindow, cbfun: Option<GLFWwindowfocusfun>) -> Option<GLFWwindowfocusfun>;
-    pub fn glfwSetWindowIconifyCallback(window: *const GLFWwindow, cbfun: Option<GLFWwindowiconifyfun>) -> Option<GLFWwindowiconifyfun>;
-    pub fn glfwSetFramebufferSizeCallback(window: *const GLFWwindow, cbfun: Option<GLFWframebuffersizefun>) -> Option<GLFWframebuffersizefun>;
+    pub fn glfwCreateWindow(width: c_int, height: c_int, title: *const c_char, monitor: *mut GLFWmonitor, share: *mut GLFWwindow) -> *mut GLFWwindow;
+    pub fn glfwDestroyWindow(window: *mut GLFWwindow);
+    pub fn glfwWindowShouldClose(window: *mut GLFWwindow) -> c_int;
+    pub fn glfwSetWindowShouldClose(window: *mut GLFWwindow, value: c_int);
+    pub fn glfwSetWindowTitle(window: *mut GLFWwindow, title: *const c_char);
+    pub fn glfwGetWindowPos(window: *mut GLFWwindow, xpos: *mut c_int, ypos: *mut c_int);
+    pub fn glfwSetWindowPos(window: *mut GLFWwindow, xpos: c_int, ypos: c_int);
+    pub fn glfwGetWindowSize(window: *mut GLFWwindow, width: *mut c_int, height: *mut c_int);
+    pub fn glfwSetWindowSize(window: *mut GLFWwindow, width: c_int, height: c_int);
+    pub fn glfwGetFramebufferSize(window: *mut GLFWwindow, width: *mut c_int, height: *mut c_int);
+    pub fn glfwIconifyWindow(window: *mut GLFWwindow);
+    pub fn glfwRestoreWindow(window: *mut GLFWwindow);
+    pub fn glfwShowWindow(window: *mut GLFWwindow);
+    pub fn glfwHideWindow(window: *mut GLFWwindow);
+    pub fn glfwGetWindowMonitor(window: *mut GLFWwindow) -> *mut GLFWmonitor;
+    pub fn glfwGetWindowAttrib(window: *mut GLFWwindow, attrib: c_int) -> c_int;
+    pub fn glfwSetWindowUserPointer(window: *mut GLFWwindow, pointer: *mut c_void);
+    pub fn glfwGetWindowUserPointer(window: *mut GLFWwindow) -> *mut c_void;
+    pub fn glfwSetWindowPosCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowposfun>) -> Option<GLFWwindowposfun>;
+    pub fn glfwSetWindowSizeCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowsizefun>) -> Option<GLFWwindowsizefun>;
+    pub fn glfwSetWindowCloseCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowclosefun>) -> Option<GLFWwindowclosefun>;
+    pub fn glfwSetWindowRefreshCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowrefreshfun>) -> Option<GLFWwindowrefreshfun>;
+    pub fn glfwSetWindowFocusCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowfocusfun>) -> Option<GLFWwindowfocusfun>;
+    pub fn glfwSetWindowIconifyCallback(window: *mut GLFWwindow, cbfun: Option<GLFWwindowiconifyfun>) -> Option<GLFWwindowiconifyfun>;
+    pub fn glfwSetFramebufferSizeCallback(window: *mut GLFWwindow, cbfun: Option<GLFWframebuffersizefun>) -> Option<GLFWframebuffersizefun>;
 
     pub fn glfwPollEvents();
     pub fn glfwWaitEvents();
 
-    pub fn glfwGetInputMode(window: *const GLFWwindow, mode: c_int) -> c_int;
-    pub fn glfwSetInputMode(window: *const GLFWwindow, mode: c_int, value: c_int);
-    pub fn glfwGetKey(window: *const GLFWwindow, key: c_int) -> c_int;
-    pub fn glfwGetMouseButton(window: *const GLFWwindow, button: c_int) -> c_int;
-    pub fn glfwGetCursorPos(window: *const GLFWwindow, xpos: *mut c_double, ypos: *mut c_double);
-    pub fn glfwSetCursorPos(window: *const GLFWwindow, xpos: c_double, ypos: c_double);
-    pub fn glfwSetKeyCallback(window: *const GLFWwindow, cbfun: Option<GLFWkeyfun>) -> Option<GLFWkeyfun>;
-    pub fn glfwSetCharCallback(window: *const GLFWwindow, cbfun: Option<GLFWcharfun>) -> Option<GLFWcharfun>;
-    pub fn glfwSetMouseButtonCallback(window: *const GLFWwindow, cbfun: Option<GLFWmousebuttonfun>) -> Option<GLFWmousebuttonfun>;
-    pub fn glfwSetCursorPosCallback(window: *const GLFWwindow, cbfun: Option<GLFWcursorposfun>) -> Option<GLFWcursorposfun>;
-    pub fn glfwSetCursorEnterCallback(window: *const GLFWwindow, cbfun: Option<GLFWcursorenterfun>) -> Option<GLFWcursorenterfun>;
-    pub fn glfwSetScrollCallback(window: *const GLFWwindow, cbfun: Option<GLFWscrollfun>) -> Option<GLFWscrollfun>;
+    pub fn glfwGetInputMode(window: *mut GLFWwindow, mode: c_int) -> c_int;
+    pub fn glfwSetInputMode(window: *mut GLFWwindow, mode: c_int, value: c_int);
+    pub fn glfwGetKey(window: *mut GLFWwindow, key: c_int) -> c_int;
+    pub fn glfwGetMouseButton(window: *mut GLFWwindow, button: c_int) -> c_int;
+    pub fn glfwGetCursorPos(window: *mut GLFWwindow, xpos: *mut c_double, ypos: *mut c_double);
+    pub fn glfwSetCursorPos(window: *mut GLFWwindow, xpos: c_double, ypos: c_double);
+    pub fn glfwSetKeyCallback(window: *mut GLFWwindow, cbfun: Option<GLFWkeyfun>) -> Option<GLFWkeyfun>;
+    pub fn glfwSetCharCallback(window: *mut GLFWwindow, cbfun: Option<GLFWcharfun>) -> Option<GLFWcharfun>;
+    pub fn glfwSetMouseButtonCallback(window: *mut GLFWwindow, cbfun: Option<GLFWmousebuttonfun>) -> Option<GLFWmousebuttonfun>;
+    pub fn glfwSetCursorPosCallback(window: *mut GLFWwindow, cbfun: Option<GLFWcursorposfun>) -> Option<GLFWcursorposfun>;
+    pub fn glfwSetCursorEnterCallback(window: *mut GLFWwindow, cbfun: Option<GLFWcursorenterfun>) -> Option<GLFWcursorenterfun>;
+    pub fn glfwSetScrollCallback(window: *mut GLFWwindow, cbfun: Option<GLFWscrollfun>) -> Option<GLFWscrollfun>;
 
     pub fn glfwJoystickPresent(joy: c_int) -> c_int;
     pub fn glfwGetJoystickAxes(joy: c_int, count: *mut c_int) -> *const c_float;
     pub fn glfwGetJoystickButtons(joy: c_int, count: *mut c_int) -> *const c_uchar;
     pub fn glfwGetJoystickName(joy: c_int) -> *const c_char;
 
-    pub fn glfwSetClipboardString(window: *const GLFWwindow, string: *const c_char);
-    pub fn glfwGetClipboardString(window: *const GLFWwindow) -> *const c_char;
+    pub fn glfwSetClipboardString(window: *mut GLFWwindow, string: *const c_char);
+    pub fn glfwGetClipboardString(window: *mut GLFWwindow) -> *const c_char;
 
     pub fn glfwGetTime() -> c_double;
     pub fn glfwSetTime(time: c_double);
 
-    pub fn glfwMakeContextCurrent(window: *const GLFWwindow);
-    pub fn glfwGetCurrentContext() -> *const GLFWwindow;
-    pub fn glfwSwapBuffers(window: *const GLFWwindow);
+    pub fn glfwMakeContextCurrent(window: *mut GLFWwindow);
+    pub fn glfwGetCurrentContext() -> *mut GLFWwindow;
+    pub fn glfwSwapBuffers(window: *mut GLFWwindow);
     pub fn glfwSwapInterval(interval: c_int);
     pub fn glfwExtensionSupported(extension: *const c_char) -> c_int;
     pub fn glfwGetProcAddress(procname: *const c_char) -> GLFWglproc;
 
     // native APIs
 
-    #[cfg(target_os="win32")] pub fn glfwGetWin32Window(window: *const GLFWwindow) -> *const c_void;
-    #[cfg(target_os="win32")] pub fn glfwGetWGLContext(window: *const GLFWwindow) -> *const c_void;
+    #[cfg(target_os="win32")] pub fn glfwGetWin32Window(window: *mut GLFWwindow) -> *mut c_void;
+    #[cfg(target_os="win32")] pub fn glfwGetWGLContext(window: *mut GLFWwindow) -> *mut c_void;
 
-    #[cfg(target_os="macos")] pub fn glfwGetCocoaWindow(window: *const GLFWwindow) -> *const c_void;
-    #[cfg(target_os="macos")] pub fn glfwGetNSGLContext(window: *const GLFWwindow) -> *const c_void;
+    #[cfg(target_os="macos")] pub fn glfwGetCocoaWindow(window: *mut GLFWwindow) -> *mut c_void;
+    #[cfg(target_os="macos")] pub fn glfwGetNSGLContext(window: *mut GLFWwindow) -> *mut c_void;
 
-    #[cfg(target_os="linux")] pub fn glfwGetX11Window(window: *const GLFWwindow) -> *const c_void;
-    #[cfg(target_os="linux")] pub fn glfwGetX11Display() -> *const c_void;
-    #[cfg(target_os="linux")] pub fn glfwGetGLXContext(window: *const GLFWwindow) -> *const c_void;
+    #[cfg(target_os="linux")] pub fn glfwGetX11Window(window: *mut GLFWwindow) -> *mut c_void;
+    #[cfg(target_os="linux")] pub fn glfwGetX11Display() -> *mut c_void;
+    #[cfg(target_os="linux")] pub fn glfwGetGLXContext(window: *mut GLFWwindow) -> *mut c_void;
 }


### PR DESCRIPTION
This was done by https://github.com/bjz/glfw-rs/pull/182. However, the
original FFI calls were all incorrectly using `*`. They now match the C
headers: `*mut T` is used when C uses `*T` and `*const T` is used when C
uses `const T *`.
