### PR TITLE
Prevent build script from confusing Cargo

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -5,4 +5,6 @@ if [ "$OS" == "Windows_NT" ]; then
 	MAKE=mingw32-make
 fi
 
-$MAKE link
+if [ ! -f src/link.rs ]; then
+	$MAKE link
+fi


### PR DESCRIPTION
It seems that re-generating link.rs in .build.sh confuses Cargo into
thinking that the code has changed and needs to be rebuilt. This commit
changes the build script to only generate link.rs, if it doesn't already
exist, thereby fixing this problem.
