### PR TITLE
Updated for latest Rust (75a39e0fb): bitflags now includes deriving(Hash).

### DIFF
--- a/src/glfw.rs
+++ b/src/glfw.rs
@@ -1021,7 +1021,6 @@ impl<'a> WindowMode<'a> {
 
 bitflags! {
     #[doc = "Key modifiers"]
-    #[deriving(Hash)]
     flags Modifiers: c_int {
         static Shift       = ffi::MOD_SHIFT,
         static Control     = ffi::MOD_CONTROL,


### PR DESCRIPTION
Fixes #202.
