### PR TITLE
Improve pkg-config error reporting

### DIFF
--- a/src/link_glfw/lib.rs
+++ b/src/link_glfw/lib.rs
@@ -69,6 +69,7 @@ pub fn expand(context: &mut base::ExtCtxt, span: codemap::Span,
         .arg("--static")
         .arg("--libs-only-l")
         .arg("--libs-only-other")
+        .arg("--print-errors")
         .arg("glfw3")
         .output();
     match out {
@@ -98,8 +99,17 @@ pub fn expand(context: &mut base::ExtCtxt, span: codemap::Span,
                 });
                 box (GC) item
             } else {
-                context.span_err(span, format!("error returned by \
-                    `pkg-config`: ({})", out.status).as_slice());
+                context.span_err( 
+                    span, 
+                    format!(
+                        "error returned by \
+                        `pkg-config`: ({})\n\
+                        `pkg-config stdout`: {}\n\
+                        `pkg-config stderr`: {}", 
+                        out.status, 
+                        String::from_utf8(out.output).unwrap(),
+                        String::from_utf8(out.error).unwrap())
+                        .as_slice());
                 item
             }
         },


### PR DESCRIPTION
This is a slightly cleaned up version of what I used to debug why pkg-config was failing (as reported in #208), with this change I get this output:

```
$ cargo build
   Compiling link_glfw v0.1.0 (file:///home/normal/rust/working/piston-examples/glfw-rs)
       Fresh semver v0.0.1 (https://github.com/rust-lang/semver#e17191f5)
   Compiling glfw v0.0.1 (file:///home/normal/rust/working/piston-examples/glfw-rs)
src/glfw/ffi/link.rs:27:1: 27:13 error: error returned by `pkg-config`: (exit code: 1)
`pkg-config stdout`: 
`pkg-config stderr`: Package glfw3 was not found in the pkg-config search path.
Perhaps you should add the directory containing `glfw3.pc'
to the PKG_CONFIG_PATH environment variable
No package 'glfw3' found

src/glfw/ffi/link.rs:27 #[link_glfw]
                        ^~~~~~~~~~~~
error: aborting due to previous error
Could not compile `glfw`.

To learn more, run the command again with --verbose.
```

I am not sure that pkg-config ever actually outputs anything to stdout, so that line may be extraneous. It also doesn't change the error message that brownhead reported, so it only partially fixes #208. There may be a better way to do this, this is just what worked for me as a quick fix.
