### PR TITLE
Update README for homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ fn handle_window_event(window: &glfw::Window, event: glfw::WindowEvent) {
 
 Make sure you have [compiled and installed GLFW 3.x](http://www.glfw.org/docs/latest/compile.html).
 You might be able to find it on your package manager, for example on OS X:
-`brew install --static glfw3`. If not you can download and build the library
+`brew install --static glfw3` (you may need to run `brew tap homebrew/versions`).
+If not you can download and build the library
 [from the source](http://www.glfw.org/docs/latest/compile.html) supplied on the
 GLFW website. Note that if you compile GLFW with CMake on Linux, you will have
 to supply the `-DCMAKE_C_FLAGS=-fPIC` argument. You may install GLFW to your


### PR DESCRIPTION
Homebrew doesn't contain a glfw3 formula in mainline, it exists in the homebrew/versions tap.
