### PR TITLE
updated "win32" to "windows" in target_os checks

### DIFF
--- a/src/glfw/ffi/link.rs
+++ b/src/glfw/ffi/link.rs
@@ -14,15 +14,15 @@
 // limitations under the License.
 
 #[phase(plugin)]
-#[cfg(not(target_os="win32"))]
+#[cfg(not(target_os="windows"))]
 extern crate link_glfw;
 
-#[cfg(target_os="win32")]
+#[cfg(target_os="windows")]
 #[link(name = "glfw3")]
 #[link(name = "opengl32")]
 #[link(name = "gdi32")]
 extern {}
 
-#[cfg(not(target_os="win32"))]
+#[cfg(not(target_os="windows"))]
 #[link_glfw]
 extern {}

--- a/src/glfw/ffi/mod.rs
+++ b/src/glfw/ffi/mod.rs
@@ -374,8 +374,8 @@ extern "C" {
 
     // native APIs
 
-    #[cfg(target_os="win32")] pub fn glfwGetWin32Window(window: *mut GLFWwindow) -> *mut c_void;
-    #[cfg(target_os="win32")] pub fn glfwGetWGLContext(window: *mut GLFWwindow) -> *mut c_void;
+    #[cfg(target_os="windows")] pub fn glfwGetWin32Window(window: *mut GLFWwindow) -> *mut c_void;
+    #[cfg(target_os="windows")] pub fn glfwGetWGLContext(window: *mut GLFWwindow) -> *mut c_void;
 
     #[cfg(target_os="macos")] pub fn glfwGetCocoaWindow(window: *mut GLFWwindow) -> *mut c_void;
     #[cfg(target_os="macos")] pub fn glfwGetNSGLContext(window: *mut GLFWwindow) -> *mut c_void;

--- a/src/glfw/lib.rs
+++ b/src/glfw/lib.rs
@@ -1457,13 +1457,13 @@ impl Window {
     }
 
     /// Wrapper for `glfwGetWin32Window`
-    #[cfg(target_os="win32")]
+    #[cfg(target_os="windows")]
     pub fn get_win32_window(&self) -> *mut c_void {
         unsafe { ffi::glfwGetWin32Window(self.ptr) }
     }
 
     /// Wrapper for `glfwGetWGLContext`
-    #[cfg(target_os="win32")]
+    #[cfg(target_os="windows")]
     pub fn get_wgl_context(&self) -> *mut c_void {
         unsafe { ffi::glfwGetWGLContext(self.ptr) }
     }


### PR DESCRIPTION
rustc now reports "windows" rather than "win32"; minor update revising the checks to build on windows.
