### PR TITLE
Update to the last rust-nightly.

### DIFF
--- a/src/glfw/lib.rs
+++ b/src/glfw/lib.rs
@@ -1076,7 +1076,7 @@ pub fn flush_messages<'a, Message: Send>(receiver: &'a Receiver<Message>) -> Flu
 
 /// An iterator that yeilds until no more messages are contained in the
 /// `Receiver`'s queue.
-pub struct FlushedMessages<'a, Message>(&'a Receiver<Message>);
+pub struct FlushedMessages<'a, Message: 'a>(&'a Receiver<Message>);
 
 impl<'a, Message: Send> Iterator<Message> for FlushedMessages<'a, Message> {
     fn next(&mut self) -> Option<Message> {


### PR DESCRIPTION
Version of rustc: 0.12.0-pre-nightly (2e92c67dc 2014-08-28 23:56:20 +0000).
