### PR TITLE
Use Cargo features to restore Windows compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,13 @@ authors = [
         "zofrex",
 ]
 
+[features]
+default = ["glfw-sys"]
+
 [dependencies.semver]
 git = "https://github.com/rust-lang/semver"
 
 [dependencies.glfw-sys]
 git = "https://github.com/servo/glfw"
 branch = "cargo-3.0.4"
+optional = true

--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ Add this to your `Cargo.toml`:
 git = "https://github.com/bjz/glfw-rs.git"
 ~~~
 
+#### On Windows
+
+By default, `glfw-rs` will try to compile the `glfw` library. If you want to link to your custom
+build of `glfw` or if the build doesn't work (which is probably the case on Windows), you can
+disable this:
+
+~~~toml
+[dependencies.glfw]
+git = "https://github.com/bjz/glfw-rs.git"
+default-features = false
+~~~
+
 ### Building and running the examples
 
 Run `cargo test`, then `./target/test/<example_name>`.

--- a/src/ffi/link.rs
+++ b/src/ffi/link.rs
@@ -18,7 +18,13 @@
 #[link(name = "gdi32")]
 extern {}
 
+#[cfg(feature = "glfw-sys")]
 #[link(name = "glfw3", kind = "static")]
+extern {}
+
+#[cfg(not(feature = "glfw-sys"))]
+// leaving off `kind = static` allows for the specification of a dynamic library if desired
+#[link(name = "glfw3")]
 extern {}
 
 #[cfg(target_os="linux")]


### PR DESCRIPTION
See this: http://crates.io/manifest.html#the-[features]-section

Using `glfw-rs` on windows:

``` toml
[dependencies.glfw-rs]
git = "https://github.com/bjz/glfw-rs"
default-features = false
```

Building `glfw-rs` on Windows: `cargo build --no-default-feature`

This will prevent the `glfw-sys` dependency from being compiled.

On any other platform, it stays the same.
