### PR TITLE
Building of example fails on x86_64-w64-mingw32 with unresolved references due to wrong linking order

### DIFF
--- a/src/ffi/link.rs
+++ b/src/ffi/link.rs
@@ -13,11 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(target_os="windows")]
-#[link(name = "opengl32")]
-#[link(name = "gdi32")]
-extern {}
-
 #[cfg(feature = "glfw-sys")]
 #[link(name = "glfw3", kind = "static")]
 extern {}
@@ -25,6 +20,11 @@ extern {}
 #[cfg(not(feature = "glfw-sys"))]
 // leaving off `kind = static` allows for the specification of a dynamic library if desired
 #[link(name = "glfw3")]
+extern {}
+
+#[cfg(target_os="windows")]
+#[link(name = "opengl32")]
+#[link(name = "gdi32")]
 extern {}
 
 #[cfg(target_os="linux")]


### PR DESCRIPTION
Trying to build the example from the readme fails with:

``` shell
d:\devel\projects\rust_tests\gl>cargo build
   Compiling gl v0.0.1 (file:///D:/devel/projects/rust_tests/gl)
error: linking with `gcc` failed: exit code: 1
note: gcc '-m64' '-L' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib' '-o' 'D:\devel\projects\rust_tests\gl\target\gl.exe' 'D:\devel\projects\rust_tests\gl\target\gl.o' '-Wl,--whole-archive' '-lmorestack' '-Wl,--no-whole-archive' '-fno-lto' '-fno-use-linker-plugin' '-Wl,--gc-sections' '-static-libgcc' '-Wl,--enable-long-section-names' '-Wl,--nxcompat' 'D:\devel\projects\rust_tests\gl\target\deps\libglfw-9f6ea9f24181e05c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\liblog-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\libnative-4e7c5e5c.rlib' 'D:\devel\projects\rust_tests\gl\target\deps\libsemver-6324dd0606536988.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\libregex-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\libstd-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\libsync-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\librustrt-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\libcollections-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\liballoc-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\liblibc-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\libunicode-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\librand-4e7c5e5c.rlib' 'D:\devel\Rust\bin\rustlib\x86_64-w64-mingw32\lib\libcore-4e7c5e5c.rlib' '-L' 'D:\devel\projects\rust_tests\gl\target' '-L' 'D:\devel\projects\rust_tests\gl\target\deps' '-L' 'D:\devel\projects\rust_tests\gl\.rust' '-L' 'D:\devel\projects\rust_tests\gl' '-Wl,--whole-archive' '-Wl,-Bstatic' '-Wl,--no-whole-archive' '-Wl,-Bdynamic' '-lopengl32' '-lgdi32' '-lglfw3' '-lws2_32' '-lcompiler-rt'
note: d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../lib/libglfw3.a(context.c.obj):context.c:(.text+0x5c): undefined reference to `glGetString'
d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../lib/libglfw3.a(context.c.obj):context.c:(.text+0x8e1): undefined reference to `glGetIntegerv'
d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../lib/libglfw3.a(context.c.obj):context.c:(.text+0x966): undefined reference to `glGetIntegerv'
d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../lib/libglfw3.a(context.c.obj):context.c:(.text+0x9dd): undefined reference to `glGetIntegerv'
d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../lib/libglfw3.a(context.c.obj):context.c:(.text+0xa34): undefined reference to `glGetIntegerv'
d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../lib/libglfw3.a(context.c.obj):context.c:(.text+0xd2d): undefined reference to `glGetString'
d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../lib/libglfw3.a(context.c.obj):context.c:(.text+0xd86): undefined reference to `glGetIntegerv'
d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../x86_64-w64-mingw32/bin/ld.exe: d:/devel/tdm-gcc/bin/../lib/gcc/x86_64-w64-mingw32/4.8.1/../../../../lib/libglfw3.a(context.c.obj): bad reloc address 0x0 in section `.pdata'
collect2.exe: error: ld returned 1 exit status

error: aborting due to previous error
Could not compile `gl`.

To learn more, run the command again with --verbose.
```

If you notice the linking order: `'-lopengl32' '-lgdi32' '-lglfw3'`, you'll see that `glfw3` comes _after_ `opengl32`, which is wrong. This patch reorders stuff in `src/ffi/link.rs` so that `glfw` comes before any platform-specific OpenGL libraries.
