### PR TITLE
Update for Cargo's platform-specific dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,21 @@ authors = [
         "zofrex",
 ]
 
-[features]
-default = ["glfw-sys"]
-
 [dependencies.semver]
 git = "https://github.com/rust-lang/semver"
 
-[dependencies.glfw-sys]
+[target.i686-unknown-linux-gnu.dependencies.glfw-sys]
 git = "https://github.com/servo/glfw"
 branch = "cargo-3.0.4"
-optional = true
+
+[target.x86_64_unknown_linux_gnu.dependencies.glfw-sys]
+git = "https://github.com/servo/glfw"
+branch = "cargo-3.0.4"
+
+[target.i686-apple-darwin.dependencies.glfw-sys]
+git = "https://github.com/servo/glfw"
+branch = "cargo-3.0.4"
+
+[target.x86_64-apple-darwin.dependencies.glfw-sys]
+git = "https://github.com/servo/glfw"
+branch = "cargo-3.0.4"

--- a/README.md
+++ b/README.md
@@ -88,15 +88,9 @@ git = "https://github.com/bjz/glfw-rs.git"
 
 #### On Windows
 
-By default, `glfw-rs` will try to compile the `glfw` library. If you want to link to your custom
-build of `glfw` or if the build doesn't work (which is probably the case on Windows), you can
-disable this:
-
-~~~toml
-[dependencies.glfw]
-git = "https://github.com/bjz/glfw-rs.git"
-default-features = false
-~~~
+On Linux and OS/X `glfw-rs` will automatically compile the `glfw` library.
+However on Windows you will need to provide `libglfw3` yourself. To do so, put
+the precompiled library in `C:\Users\<you>\.rust`.
 
 ### Building and running the examples
 


### PR DESCRIPTION
`glfw-sys` is now built only on `i686-unknown-linux-gnu`, `x86_64_unknown_linux_gnu`, `i686-apple-darwin` and `x86_64-apple-darwin` (all relevant platforms but windows).

In the long-term this should be changed again to use the new build commands system that has been accepted but is not yet implemented in Cargo.

**Note**: I didn't test if it works on Linux because platform-specific dependencies are not in the Cargo nightlies yet. I recommend quickly trying on OS/X too.
