### PR TITLE
Fix README to show enum namespacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GLFW bindings and wrapper for The Rust Programming Language.
 extern crate native;
 extern crate glfw;
 
-use glfw::Context;
+use glfw::{Action, Context, Key};
 
 #[start]
 fn start(argc: int, argv: *const *const u8) -> int {
@@ -51,7 +51,7 @@ fn main() {
 
 fn handle_window_event(window: &glfw::Window, event: glfw::WindowEvent) {
     match event {
-        glfw::KeyEvent(glfw::KeyEscape, _, glfw::Press, _) => {
+        glfw::KeyEvent(Key::Escape, _, Action::Press, _) => {
             window.set_should_close(true)
         }
         _ => {}


### PR DESCRIPTION
Following pull request #241 the example code in the README.md would fail to compile. Therefore I've updated it in the same style as the examples.
