### PR TITLE
Fix old closure syntax to unboxed closures.

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -77,7 +77,7 @@ pub mod error {
     callback!(
         type Args = (error: ::Error, description: String);
         type Callback = ErrorCallback;
-        let ext_set = |cb| unsafe { ::ffi::glfwSetErrorCallback(cb) };
+        let ext_set = |&:cb| unsafe { ::ffi::glfwSetErrorCallback(cb) };
         fn callback(error: c_int, description: *const c_char) {
             (mem::transmute(error), string::String::from_raw_buf(
                 description as *const u8))
@@ -94,7 +94,7 @@ pub mod monitor {
     callback!(
         type Args = (monitor: ::Monitor, event: ::MonitorEvent);
         type Callback = MonitorCallback;
-        let ext_set = |cb| unsafe { ::ffi::glfwSetMonitorCallback(cb) };
+        let ext_set = |&:cb| unsafe { ::ffi::glfwSetMonitorCallback(cb) };
         fn callback(monitor: *mut ::ffi::GLFWmonitor, event: c_int) {
             let monitor = ::Monitor {
                 ptr: monitor,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,7 +477,7 @@ impl Glfw {
     ///         m.map_or(glfw::WindowMode::Windowed, |m| glfw::FullScreen(m)))
     /// }).expect("Failed to create GLFW window.");
     /// ~~~
-    pub fn with_primary_monitor<T>(&self, f: |Option<&Monitor>| -> T) -> T {
+    pub fn with_primary_monitor<T, F>(&self, f: F) -> T where F: Fn(Option<&Monitor>) -> T {
         match unsafe { ffi::glfwGetPrimaryMonitor() } {
             ptr if ptr.is_null() => f(None),
             ptr => f(Some(&Monitor {
@@ -501,7 +501,7 @@ impl Glfw {
     ///     }
     /// });
     /// ~~~
-    pub fn with_connected_monitors<T>(&self, f: |&[Monitor]| -> T) -> T {
+    pub fn with_connected_monitors<T, F>(&self, f: F) -> T where F: Fn(&[Monitor]) -> T {
         unsafe {
             let mut count = 0;
             let ptr = ffi::glfwGetMonitors(&mut count);
@@ -1238,7 +1238,7 @@ impl Window {
     ///     }
     /// });
     /// ~~~
-    pub fn with_window_mode<T>(&self, f: |WindowMode| -> T) -> T {
+    pub fn with_window_mode<T, F>(&self, f: F) -> T where F: Fn(WindowMode) -> T {
         let ptr = unsafe { ffi::glfwGetWindowMonitor(self.ptr) };
         if ptr.is_null() {
             f(WindowMode::Windowed)


### PR DESCRIPTION
I'm not sure if this is correct, but it does compile. I have not been able to test it yet, as I haven't gotten my project that uses glfw-rs to compile with the latest nightlies. Once I get that working, I'll know better if this works.