### PR TITLE
Update to latest Rust nightly

### DIFF
--- a/examples/error.rs
+++ b/examples/error.rs
@@ -15,10 +15,8 @@
 
 //! Demonstrates how custom error callbacks with user data can be created
 
-#![feature(phase)]
-
 extern crate glfw;
-#[phase(plugin, link)] extern crate log;
+#[macro_use] extern crate log;
 
 use std::cell::Cell;
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -72,15 +72,13 @@ pub mod error {
     use libc::{c_int, c_char};
     use std::cell::RefCell;
     use std::mem;
-    use std::string;
 
     callback!(
         type Args = (error: ::Error, description: String);
         type Callback = ErrorCallback;
-        let ext_set = |cb| unsafe { ::ffi::glfwSetErrorCallback(cb) };
+        let ext_set = |&: cb| unsafe { ::ffi::glfwSetErrorCallback(cb) };
         fn callback(error: c_int, description: *const c_char) {
-            (mem::transmute(error), string::String::from_raw_buf(
-                description as *const u8))
+            (mem::transmute(error), ::string_from_c_str(description))
         }
     );
 }
@@ -94,7 +92,7 @@ pub mod monitor {
     callback!(
         type Args = (monitor: ::Monitor, event: ::MonitorEvent);
         type Callback = MonitorCallback;
-        let ext_set = |cb| unsafe { ::ffi::glfwSetMonitorCallback(cb) };
+        let ext_set = |&: cb| unsafe { ::ffi::glfwSetMonitorCallback(cb) };
         fn callback(monitor: *mut ::ffi::GLFWmonitor, event: c_int) {
             let monitor = ::Monitor {
                 ptr: monitor,


### PR DESCRIPTION
Fixes breakages after changes to C string handling and the switch to unboxed closures in the last couple Rust nightlies.

Compiles and tests successfully as of the opening of this PR. I ignored the warnings for missing `Copy` implementations as I figured making certain structs `Copy` within the `ffi` module merited some discussion.