### PR TITLE
Minor cleanup

### DIFF
--- a/examples/error.rs
+++ b/examples/error.rs
@@ -23,7 +23,7 @@ use std::cell::Cell;
 fn main() {
     let glfw = glfw::init(Some(
         glfw::Callback {
-            f: error_callback as fn(glfw::Error, String, &Cell<uint>),
+            f: error_callback as fn(glfw::Error, String, &Cell<usize>),
             data: Cell::new(0),
         }
     )).unwrap();
@@ -35,7 +35,7 @@ fn main() {
     let _ = glfw.create_window(300, 300, "Stop it! :(",          glfw::WindowMode::Windowed);
 }
 
-fn error_callback(_: glfw::Error, description: String, error_count: &Cell<uint>) {
+fn error_callback(_: glfw::Error, description: String, error_count: &Cell<usize>) {
     error!("GLFW error {:?}: {:?}", error_count.get(), description);
     error_count.set(error_count.get() + 1);
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -87,7 +87,6 @@ pub mod monitor {
     use libc::{c_int};
     use std::cell::RefCell;
     use std::mem;
-    use std::marker;
 
     callback!(
         type Args = (monitor: ::Monitor, event: ::MonitorEvent);
@@ -95,10 +94,7 @@ pub mod monitor {
         let ext_set = |&: cb| unsafe { ::ffi::glfwSetMonitorCallback(cb) };
         fn callback(monitor: *mut ::ffi::GLFWmonitor, event: c_int) {
             let monitor = ::Monitor {
-                ptr: monitor,
-                no_copy: marker::NoCopy,
-                no_send: marker::NoSend,
-                no_share: marker::NoSync,
+                ptr: monitor
             };
             (monitor, mem::transmute(event))
         }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -270,8 +270,10 @@ pub type GLFWkeyfun             = extern "C" fn(*mut GLFWwindow, c_int, c_int, c
 pub type GLFWcharfun            = extern "C" fn(*mut GLFWwindow, c_uint);
 pub type GLFWmonitorfun         = extern "C" fn(*mut GLFWmonitor, c_int);
 
+#[allow(missing_copy_implementations)]
 pub enum GLFWmonitor {}
 
+#[allow(missing_copy_implementations)]
 pub enum GLFWwindow {}
 
 #[repr(C)]
@@ -284,6 +286,7 @@ pub struct GLFWgammaramp {
 
 impl Copy for GLFWgammaramp {}
 
+#[allow(missing_copy_implementations)]
 #[repr(C)]
 pub struct GLFWvidmode {
     pub width:       c_int,


### PR DESCRIPTION
- Remove use of markers
- use slice::from_raw_buf instead of vec::Vec::from_raw_buf (safer life times)
- get_gamma_ramp had a questionable conversion to a Vec.