### PR TITLE
As a fallout of the mutability change some apis need to be tweaked.

### DIFF
--- a/examples/modes.rs
+++ b/examples/modes.rs
@@ -16,9 +16,9 @@
 extern crate glfw;
 
 fn main() {
-    let glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
-    glfw.with_primary_monitor(|monitor| {
+    glfw.with_primary_monitor(|_, monitor| {
         let _ = monitor.map(|monitor| {
             println!("{:?}:", monitor.get_name());
             println!("    {:?}\n", monitor.get_video_mode().unwrap());
@@ -27,7 +27,7 @@ fn main() {
 
     println!("Available monitors\n\
               ------------------");
-    glfw.with_connected_monitors(|monitors| {
+    glfw.with_connected_monitors(|_, monitors| {
         for monitor in monitors.iter() {
             println!("{:?}:", monitor.get_name());
             for mode in monitor.get_video_modes().iter() {

--- a/examples/monitors.rs
+++ b/examples/monitors.rs
@@ -20,13 +20,13 @@ use glfw::{Action, Context, Key};
 fn main() {
     let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
-    glfw.with_connected_monitors(|monitors| {
+    glfw.with_connected_monitors(|_, monitors| {
         for monitor in monitors.iter() {
             println!("{:?}: {:?}", monitor.get_name(), monitor.get_video_mode());
         }
     });
 
-    let (mut window, events) = glfw.with_primary_monitor(|m| {
+    let (mut window, events) = glfw.with_primary_monitor(|glfw, m| {
         glfw.create_window(300, 300, "Hello this is window",
             m.map_or(glfw::WindowMode::Windowed, |m| glfw::WindowMode::FullScreen(m)))
     }).expect("Failed to create GLFW window.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -473,10 +473,10 @@ impl Glfw {
     ///         m.map_or(glfw::WindowMode::Windowed, |m| glfw::FullScreen(m)))
     /// }).expect("Failed to create GLFW window.");
     /// ~~~
-    pub fn with_primary_monitor<T, F>(&self, f: F) -> T where F: Fn(Option<&Monitor>) -> T {
+    pub fn with_primary_monitor<T, F>(&mut self, f: F) -> T where F: Fn(&mut Self, Option<&Monitor>) -> T {
         match unsafe { ffi::glfwGetPrimaryMonitor() } {
-            ptr if ptr.is_null() => f(None),
-            ptr => f(Some(&Monitor {
+            ptr if ptr.is_null() => f(self, None),
+            ptr => f(self, Some(&Monitor {
                 ptr: ptr
             })),
         }
@@ -494,11 +494,12 @@ impl Glfw {
     ///     }
     /// });
     /// ~~~
-    pub fn with_connected_monitors<T, F>(&self, f: F) -> T where F: Fn(&[Monitor]) -> T {
+    pub fn with_connected_monitors<T, F>(&mut self, f: F) -> T where F: Fn(&mut Self, &[Monitor]) -> T {
         unsafe {
             let mut count = 0;
             let ptr = ffi::glfwGetMonitors(&mut count);
-            f(slice::from_raw_buf(&(ptr as *const _), count as usize).iter().map(|&ptr| {
+            f(self,
+              slice::from_raw_buf(&(ptr as *const _), count as usize).iter().map(|&ptr| {
                 Monitor {
                     ptr: ptr
                 }


### PR DESCRIPTION
The apis that query the monitors are no longer useful, since you cannot take
a &mut Glfw if it is already borrowed as &Glfw. So you could query the screens,
but the value was useless when it came to actually creating a window with a screen.