### PR TITLE
Fix unwrap in example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ extern crate glfw;
 use glfw::{Action, Context, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
 
     let (mut window, events) = glfw.create_window(300, 300, "Hello this is window", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");


### PR DESCRIPTION
Fix the example code in README similar to what commit bc1b352 ("Fix
unwrap in examples") did for the examples.

Signed-off-by: Pekka Enberg <penberg@iki.fi>