### PR TITLE
Use fmt::Display in InitError.

### DIFF
--- a/examples/clipboard.rs
+++ b/examples/clipboard.rs
@@ -18,7 +18,7 @@ extern crate glfw;
 use glfw::{Action, Context, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     let (mut window, events) = glfw.create_window(300, 300, "Clipboard Test", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -18,7 +18,7 @@ extern crate glfw;
 use glfw::{Action, Context, CursorMode, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     let (mut window, events) = glfw.create_window(800, 600, "Hello, I am a window.", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");

--- a/examples/defaults.rs
+++ b/examples/defaults.rs
@@ -18,7 +18,7 @@ extern crate glfw;
 use glfw::Context;
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     glfw.window_hint(glfw::WindowHint::Visible(true));
 

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -26,7 +26,7 @@ fn main() {
             f: error_callback as fn(glfw::Error, String, &Cell<usize>),
             data: Cell::new(0),
         }
-    )).ok().expect("Failed to init glfw");
+    )).unwrap();
 
     // Force the error callback to be triggered
     glfw.window_hint(glfw::WindowHint::ContextVersion(40000, 3000)); // Ridiculous!

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -18,7 +18,7 @@ extern crate glfw;
 use glfw::{Action, Context, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     glfw.window_hint(glfw::WindowHint::Resizable(true));
 

--- a/examples/modes.rs
+++ b/examples/modes.rs
@@ -16,7 +16,7 @@
 extern crate glfw;
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     glfw.with_primary_monitor(|_, monitor| {
         let _ = monitor.map(|monitor| {

--- a/examples/monitors.rs
+++ b/examples/monitors.rs
@@ -18,7 +18,7 @@ extern crate glfw;
 use glfw::{Action, Context, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     glfw.with_connected_monitors(|_, monitors| {
         for monitor in monitors.iter() {

--- a/examples/render_task.rs
+++ b/examples/render_task.rs
@@ -23,7 +23,7 @@ use glfw::{Action, Context, Key};
 use std::thread::Builder;
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     let (mut window, events) = glfw.create_window(300, 300, "Hello this is window", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");

--- a/examples/title.rs
+++ b/examples/title.rs
@@ -18,7 +18,7 @@ extern crate glfw;
 use glfw::{Action, Context, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     let (mut window, events) = glfw.create_window(400, 400, "English 日本語 русский язык 官話", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -18,7 +18,7 @@ extern crate glfw;
 use glfw::{Action, Context, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     let (mut window, events) = glfw.create_window(300, 300, "Hello this is window", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! use glfw::{Action, Context, Key};
 //!
 //! fn main() {
-//!    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+//!    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 //!
 //!     // Create a windowed mode window and its OpenGL context
 //!     let (mut window, events) = glfw.create_window(300, 300, "Hello this is window", glfw::WindowMode::Windowed)
@@ -360,6 +360,12 @@ pub enum InitError {
     Internal,
 }
 
+impl fmt::Display for InitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "InitError: {:?}", *self)
+    }
+}
+
 /// Initializes the GLFW library. This must be called on the main platform
 /// thread.
 ///
@@ -377,7 +383,7 @@ pub enum InitError {
 /// extern crate glfw;
 ///
 /// fn main() {
-///    let glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+///    let glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 /// }
 /// ~~~
 ///


### PR DESCRIPTION
Revert change to use .ok().except(...)

In response to @tomaka's comment on https://github.com/bjz/glfw-rs/pull/280#issuecomment-71368742.