### PR TITLE
Missed in #282.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ extern crate glfw;
 use glfw::{Action, Context, Key};
 
 fn main() {
-    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).ok().expect("Failed to init glfw");
+    let mut glfw = glfw::init(glfw::FAIL_ON_ERRORS).unwrap();
 
     let (mut window, events) = glfw.create_window(300, 300, "Hello this is window", glfw::WindowMode::Windowed)
         .expect("Failed to create GLFW window.");


### PR DESCRIPTION
Revert "Fix unwrap in example code in README"

This reverts commit 47906f8160e3035fc1a5dc27c8335b5c8ad2f6bd.