### PR TITLE
Removed usage of the old box syntax.

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -43,7 +43,7 @@ macro_rules! callback(
         }
 
         pub fn set<UserData: 'static>(f: ::$Callback<UserData>) {
-            let mut boxed_cb = Some(box f as Box<Object<Args> + 'static>);
+            let mut boxed_cb = Some(Box::new(f) as Box<Object<Args> + 'static>);
             CALLBACK_KEY.with(|cb| {
                 *cb.borrow_mut() = boxed_cb.take();
             });


### PR DESCRIPTION
Removed the last usage of the old box syntax.
This fixes the build on the current nightly (2015-03-07) without requiring the feature gate to be enabled.