### PR TITLE
Also link to libraries on other systems

### DIFF
--- a/src/ffi/link.rs
+++ b/src/ffi/link.rs
@@ -27,7 +27,7 @@ extern {}
 #[link(name = "gdi32")]
 extern {}
 
-#[cfg(target_os="linux")]
+#[cfg(any(target_os="linux", target_os="freebsd", target_os="dragonfly"))]
 #[link(name = "X11")]
 #[link(name = "GL")]
 #[link(name = "Xxf86vm")]


### PR DESCRIPTION
This has been tested on DragonFly BSD.
It is assumed to be the same on FreeBSD and many other BSDs which
use X11.