### PR TITLE
Update to GLFW 3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .DS_Store
 /target/
 /Cargo.lock
+
+# RustRover clutter
+.idea

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -246,6 +246,10 @@ pub const VERSION_UNAVAILABLE: c_int = 0x00010007;
 pub const PLATFORM_ERROR: c_int = 0x00010008;
 pub const FORMAT_UNAVAILABLE: c_int = 0x00010009;
 pub const NO_WINDOW_CONTEXT: c_int = 0x0001000A;
+pub const CURSOR_UNAVAILABLE: c_int = 0x0001000B;
+pub const FEATURE_UNAVAILABLE: c_int = 0x0001000C;
+pub const FEATURE_UNIMPLEMENTED: c_int = 0x0001000D;
+pub const PLATFORM_UNAVAILABLE: c_int = 0x0001000E;
 
 pub const FOCUSED: c_int = 0x00020001;
 pub const ICONIFIED: c_int = 0x00020002;
@@ -259,6 +263,9 @@ pub const CENTER_CURSOR: c_int = 0x00020009;
 pub const TRANSPARENT_FRAMEBUFFER: c_int = 0x0002000A;
 pub const HOVERED: c_int = 0x0002000B;
 pub const FOCUS_ON_SHOW: c_int = 0x0002000C;
+pub const MOUSE_PASSTHROUGH: c_int = 0x0002000D;
+pub const POSITION_X: c_int = 0x0002000E;
+pub const POSITION_Y: c_int = 0x0002000F;
 
 pub const RED_BITS: c_int = 0x00021001;
 pub const GREEN_BITS: c_int = 0x00021002;
@@ -283,12 +290,16 @@ pub const CONTEXT_VERSION_MINOR: c_int = 0x00022003;
 pub const CONTEXT_REVISION: c_int = 0x00022004;
 pub const CONTEXT_ROBUSTNESS: c_int = 0x00022005;
 pub const OPENGL_FORWARD_COMPAT: c_int = 0x00022006;
-pub const OPENGL_DEBUG_CONTEXT: c_int = 0x00022007;
+pub const CONTEXT_DEBUG: c_int = 0x00022007;
 pub const OPENGL_PROFILE: c_int = 0x00022008;
 pub const CONTEXT_RELEASE_BEHAVIOR: c_int = 0x00022009;
 pub const CONTEXT_NO_ERROR: c_int = 0x0002200A;
 pub const CONTEXT_CREATION_API: c_int = 0x0002200B;
 pub const SCALE_TO_MONITOR: c_int = 0x0002200C;
+pub const SCALE_FRAMEBUFFER: c_int = 0x0002200D;
+
+// alias for compatibility
+pub const OPENGL_DEBUG_CONTEXT: c_int = CONTEXT_DEBUG;
 
 pub const COCOA_RETINA_FRAMEBUFFER: c_int = 0x00023001;
 pub const COCOA_FRAME_NAME: c_int = 0x00023002;
@@ -296,6 +307,11 @@ pub const COCOA_GRAPHICS_SWITCHING: c_int = 0x00023003;
 
 pub const X11_CLASS_NAME: c_int = 0x00024001;
 pub const X11_INSTANCE_NAME: c_int = 0x00024002;
+
+pub const WIN32_KEYBOARD_MENU: c_int = 0x00025001;
+pub const WIN32_SHOWDEFAULT: c_int = 0x00025002;
+
+pub const WAYLAND_APP_ID: c_int = 0x00026001;
 
 pub const NO_API: c_int = 0x00000000;
 pub const OPENGL_API: c_int = 0x00030001;
@@ -318,6 +334,7 @@ pub const RAW_MOUSE_MOTION: c_int = 0x00033005;
 pub const CURSOR_NORMAL: c_int = 0x00034001;
 pub const CURSOR_HIDDEN: c_int = 0x00034002;
 pub const CURSOR_DISABLED: c_int = 0x00034003;
+pub const CURSOR_CAPTURED: c_int = 0x00034004;
 
 pub const ANY_RELEASE_BEHAVIOR: c_int = 0;
 pub const RELEASE_BEHAVIOR_FLUSH: c_int = 0x00035001;
@@ -327,12 +344,35 @@ pub const NATIVE_CONTEXT_API: c_int = 0x00036001;
 pub const EGL_CONTEXT_API: c_int = 0x00036002;
 pub const OSMESA_CONTEXT_API: c_int = 0x00036003;
 
+pub const ANGLE_PLATFORM_TYPE_NONE: c_int = 0x00037001;
+pub const ANGLE_PLATFORM_TYPE_OPENGL: c_int = 0x00037002;
+pub const ANGLE_PLATFORM_TYPE_OPENGLES: c_int = 0x00037003;
+pub const ANGLE_PLATFORM_TYPE_D3D9: c_int = 0x00037004;
+pub const ANGLE_PLATFORM_TYPE_D3D11: c_int = 0x00037005;
+pub const ANGLE_PLATFORM_TYPE_VULKAN: c_int = 0x00037007;
+pub const ANGLE_PLATFORM_TYPE_METAL: c_int = 0x00037008;
+
+pub const WAYLAND_PREFER_LIBDECOR: c_int = 0x00038001;
+pub const WAYLAND_DISABLE_LIBDECOR: c_int = 0x00038002;
+
+#[allow(overflowing_literals)]
+pub const ANY_POSITION: c_int = 0x80000000;
+
 pub const ARROW_CURSOR: c_int = 0x00036001;
 pub const IBEAM_CURSOR: c_int = 0x00036002;
 pub const CROSSHAIR_CURSOR: c_int = 0x00036003;
-pub const HAND_CURSOR: c_int = 0x00036004;
-pub const HRESIZE_CURSOR: c_int = 0x00036005;
-pub const VRESIZE_CURSOR: c_int = 0x00036006;
+pub const POINTING_HAND_CURSOR: c_int = 0x00036004;
+pub const RESIZE_EW_CURSOR: c_int = 0x00036005;
+pub const RESIZE_NS_CURSOR: c_int = 0x00036006;
+pub const RESIZE_NWSE_CURSOR: c_int = 0x00036007;
+pub const RESIZE_NESW_CURSOR: c_int = 0x00036008;
+pub const RESIZE_ALL_CURSOR: c_int = 0x00036009;
+pub const NOT_ALLOWED_CURSOR: c_int = 0x0003600A;
+
+// aliases for compatibility
+pub const HAND_CURSOR: c_int = POINTING_HAND_CURSOR;
+pub const HRESIZE_CURSOR: c_int = RESIZE_EW_CURSOR;
+pub const VRESIZE_CURSOR: c_int = RESIZE_NS_CURSOR;
 
 pub const CONNECTED: c_int = 0x00040001;
 pub const DISCONNECTED: c_int = 0x00040002;
@@ -340,14 +380,28 @@ pub const DISCONNECTED: c_int = 0x00040002;
 pub const DONT_CARE: c_int = -1; //negative one is the correct value
 
 pub const JOYSTICK_HAT_BUTTONS: c_int = 0x00050001;
+pub const ANGLE_PLATFORM_TYPE: c_int = 0x00050002;
+pub const PLATFORM: c_int = 0x00050003;
 pub const COCOA_CHDIR_RESOURCES: c_int = 0x00051001;
 pub const COCOA_MENUBAR: c_int = 0x00051002;
+pub const X11_XCB_VULKAN_SURFACE: c_int = 0x0005200;
+pub const WAYLAND_LIBDECOR: c_int = 0x00053001;
+
+pub const ANY_PLATFORM: c_int = 0x00060000;
+pub const PLATFORM_WIN32: c_int = 0x00060001;
+pub const PLATFORM_COCOA: c_int = 0x00060002;
+pub const PLATFORM_WAYLAND: c_int = 0x00060003;
+pub const PLATFORM_X11: c_int = 0x00060004;
+pub const PLATFORM_NULL: c_int = 0x00060005;
 
 pub type GLFWglproc = *const c_void;
 
 #[cfg(feature = "vulkan")]
 pub type GLFWvkproc = *const c_void;
 
+pub type GLFWallocatefun = extern "C" fn(size: usize, user: *const c_void) -> *const c_void;
+pub type GLFWreallocatefun = extern "C" fn(block: *const c_void, size: usize, user: *const c_void);
+pub type GLFWdeallocatefun = extern "C" fn(block: *const c_void, user: *const c_void);
 pub type GLFWerrorfun = extern "C" fn(c_int, *const c_char);
 pub type GLFWwindowposfun = extern "C" fn(*mut GLFWwindow, c_int, c_int);
 pub type GLFWwindowsizefun = extern "C" fn(*mut GLFWwindow, c_int, c_int);
@@ -418,6 +472,16 @@ pub struct GLFWimage {
 pub struct GLFWgamepadstate {
     pub buttons: [c_uchar; (GAMEPAD_BUTTON_LAST + 1) as usize],
     pub axes: [c_float; (GAMEPAD_AXIS_LAST + 1) as usize],
+}
+
+#[allow(missing_copy_implementations)]
+#[repr(C)]
+#[derive(Debug)]
+pub struct GLFWallocator {
+    pub allocate: GLFWallocatefun,
+    pub reallocate: GLFWreallocatefun,
+    pub deallocate: GLFWdeallocatefun,
+    pub user: *mut c_void,
 }
 
 // C function bindings
@@ -648,6 +712,13 @@ extern "C" {
     pub fn glfwGetGamepadName(jid: c_int) -> *const c_char;
     pub fn glfwGetGamepadState(jid: c_int, state: *mut GLFWgamepadstate) -> c_int;
 
+    // Added in 3.4
+
+    pub fn glfwInitAllocator(allocator: *const GLFWallocator);
+    pub fn glfwGetPlatform() -> c_int;
+    pub fn glfwPlatformSupported(platform: c_int) -> c_int;
+    pub fn glfwGetWindowTitle(window: *mut GLFWwindow) -> *const c_char;
+
     // Vulkan support
 
     #[cfg(feature = "vulkan")]
@@ -669,6 +740,8 @@ extern "C" {
         allocator: *const vk::AllocationCallbacks<'_>,
         surface: *mut vk::SurfaceKHR,
     ) -> vk::Result;
+    #[cfg(feature = "vulkan")]
+    pub fn glfwInitVulkanLoader(loader: vk::PFN_vkGetInstanceProcAddr);
 
     // native APIs
 
@@ -679,6 +752,8 @@ extern "C" {
 
     #[cfg(target_os = "macos")]
     pub fn glfwGetCocoaWindow(window: *mut GLFWwindow) -> *mut c_void;
+    #[cfg(target_os = "macos")]
+    pub fn glfwGetCocoaView(window: *mut GLFWwindow) -> *mut c_void;
     #[cfg(target_os = "macos")]
     pub fn glfwGetNSGLContext(window: *mut GLFWwindow) -> *mut c_void;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,14 +701,51 @@ pub enum StandardCursor {
     Arrow = ffi::ARROW_CURSOR,
     /// The text input I-beam cursor shape.
     IBeam = ffi::IBEAM_CURSOR,
-    /// The crosshair shape.
+    /// The crosshair cursor shape.
     Crosshair = ffi::CROSSHAIR_CURSOR,
-    /// The hand shape.
-    Hand = ffi::HAND_CURSOR,
-    /// The horizontal resize arrow shape.
-    HResize = ffi::HRESIZE_CURSOR,
-    /// The vertical resize arrow shape.
-    VResize = ffi::VRESIZE_CURSOR,
+    /// The pointing hand cursor shape.
+    PointingHand = ffi::POINTING_HAND_CURSOR,
+    /// The horizontal resize/move arrow shape. This is usually a horizontal
+    /// double-headed arrow.
+    ResizeEW = ffi::RESIZE_EW_CURSOR,
+    /// The vertical resize/move arrow shape. This is usually a vertical double-headed
+    /// arrow.
+    ResizeNS = ffi::RESIZE_NS_CURSOR,
+    /// The top-left to bottom-right diagonal resize/move arrow shape.
+    ///
+    /// Note that on macOS this shape is provided by a private system API and may fail
+    /// with [`ffi::CURSOR_UNAVAILABLE`] in the future.
+    ///
+    /// Note that on Wayland this shape is provided by a newer standard not supported by
+    /// all cursor themes.
+    ///
+    /// Note that on X11 this shape is provided by a newer standard not supported by all
+    /// cursor themes.
+    ResizeNWSE = ffi::RESIZE_NWSE_CURSOR,
+    /// The top-right to bottom-left diagonal resize/move arrow shape. This is usually a diagonal
+    /// double-headed arrow.
+    ///
+    /// Note that on macOS this shape is provided by a private system API and may fail
+    /// with [`ffi::CURSOR_UNAVAILABLE`] in the future.
+    ///
+    /// Note that on Wayland this shape is provided by a newer standard not supported by
+    /// all cursor themes.
+    ///
+    /// Note that on X11 this shape is provided by a newer standard not supported by all
+    /// cursor themes.
+    ResizeNESW = ffi::RESIZE_NESW_CURSOR,
+    /// The omnidirectional resize cursor/move shape.  This is usually either a combined
+    /// horizontal and vertical double-headed arrow or a grabbing hand.
+    ResizeAll = ffi::RESIZE_ALL_CURSOR,
+    /// The operation-not-allowed shape.  This is usually a circle with a diagonal line
+    /// through it.
+    ///
+    /// Note that on Wayland this shape is provided by a newer standard not supported by
+    /// all cursor themes.
+    ///
+    /// Note that on X11 this shape is provided by a newer standard not supported by all
+    /// cursor themes.
+    NotAllowed = ffi::NOT_ALLOWED_CURSOR,
 }
 
 /// Represents a window cursor that can be used to display any

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2298,10 +2298,10 @@ pub enum WindowHint {
     ///
     /// Simpler programs and tools may want to enable this to save power, while games and other
     /// applications performing advanced rendering will want to leave it disabled.
-    //
-    //  A bundled application that wishes to participate in Automatic Graphics Switching should also
-    // declare this in its `Info.plist` by setting the `NSSupportsAutomaticGraphicsSwitching` key to
-    // `true`.
+    ///
+    ///  A bundled application that wishes to participate in Automatic Graphics Switching should also
+    /// declare this in its `Info.plist` by setting the `NSSupportsAutomaticGraphicsSwitching` key to
+    /// `true`.
     ///
     /// This only affects systems with both integrated and discrete GPUs. This is ignored on
     /// platforms besides macOS.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -608,6 +608,10 @@ pub enum Error {
     PlatformError = ffi::PLATFORM_ERROR,
     FormatUnavailable = ffi::FORMAT_UNAVAILABLE,
     NoWindowContext = ffi::NO_WINDOW_CONTEXT,
+    CursorUnavailable = ffi::CURSOR_UNAVAILABLE,
+    FeatureUnavailable = ffi::FEATURE_UNAVAILABLE,
+    FeatureUnimplemented = ffi::FEATURE_UNIMPLEMENTED,
+    PlatformUnavailable = ffi::PLATFORM_UNAVAILABLE,
 }
 
 impl fmt::Display for Error {
@@ -624,6 +628,10 @@ impl fmt::Display for Error {
             Error::PlatformError => "PlatformError",
             Error::FormatUnavailable => "FormatUnavailable",
             Error::NoWindowContext => "NoWindowContext",
+            Error::CursorUnavailable => "CursorUnavailable",
+            Error::FeatureUnavailable => "FeatureUnavailable",
+            Error::FeatureUnimplemented => "FeatureUnimplemented",
+            Error::PlatformUnavailable => "PlatformUnavailable",
         };
 
         f.write_str(description)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1389,8 +1389,8 @@ impl Glfw {
             WindowHint::OpenGlForwardCompat(is_compat) => unsafe {
                 ffi::glfwWindowHint(ffi::OPENGL_FORWARD_COMPAT, is_compat as c_int)
             },
-            WindowHint::OpenGlDebugContext(is_debug) => unsafe {
-                ffi::glfwWindowHint(ffi::OPENGL_DEBUG_CONTEXT, is_debug as c_int)
+            WindowHint::ContextDebug(is_debug) => unsafe {
+                ffi::glfwWindowHint(ffi::CONTEXT_DEBUG, is_debug as c_int)
             },
             WindowHint::OpenGlProfile(profile) => unsafe {
                 ffi::glfwWindowHint(ffi::OPENGL_PROFILE, profile as c_int)
@@ -1440,8 +1440,21 @@ impl Glfw {
             WindowHint::ScaleToMonitor(scale) => unsafe {
                 ffi::glfwWindowHint(ffi::SCALE_TO_MONITOR, scale as c_int)
             },
-            WindowHint::CocoaRetinaFramebuffer(retina_fb) => unsafe {
-                ffi::glfwWindowHint(ffi::COCOA_RETINA_FRAMEBUFFER, retina_fb as c_int)
+            WindowHint::ScaleFramebuffer(scale_fb) => unsafe {
+                ffi::glfwWindowHint(ffi::SCALE_FRAMEBUFFER, scale_fb as c_int)
+            },
+            WindowHint::MousePassthrough(passthrough) => unsafe {
+                ffi::glfwWindowHint(ffi::MOUSE_PASSTHROUGH, passthrough as c_int)
+            },
+            WindowHint::Position(x, y) => unsafe {
+                ffi::glfwWindowHint(ffi::POSITION_X, x.map(|v| v as c_int).unwrap_or(ffi::ANY_POSITION));
+                ffi::glfwWindowHint(ffi::POSITION_X, y.map(|v| v as c_int).unwrap_or(ffi::ANY_POSITION));
+            },
+            WindowHint::Win32KeyboardMenu(keyboard_menu) => unsafe {
+                ffi::glfwWindowHint(ffi::WIN32_KEYBOARD_MENU, keyboard_menu as c_int)
+            },
+            WindowHint::Win32ShowDefault(show_default) => unsafe {
+                ffi::glfwWindowHint(ffi::WIN32_SHOWDEFAULT, show_default as c_int)
             },
             WindowHint::CocoaFrameName(name) => unsafe { string_hint(ffi::COCOA_FRAME_NAME, name) },
             WindowHint::CocoaGraphicsSwitching(graphics_switching) => unsafe {
@@ -1453,6 +1466,9 @@ impl Glfw {
             WindowHint::X11InstanceName(instance_name) => unsafe {
                 string_hint(ffi::X11_INSTANCE_NAME, instance_name)
             },
+            WindowHint::WaylandAppId(app_id) => unsafe {
+                string_hint(ffi::WAYLAND_APP_ID, app_id)
+            }
         }
     }
 
@@ -2274,11 +2290,9 @@ pub enum WindowHint {
     ///
     /// If another client API is requested, this hint is ignored.
     OpenGlForwardCompat(bool),
-    /// Specifies whether to create a debug OpenGL context, which may have
-    /// additional error and performance issue reporting functionality.
-    ///
-    /// If another client API is requested, this hint is ignored.
-    OpenGlDebugContext(bool),
+    /// Specifies whether the context should be created in debug mode, which may provide additional
+    /// error and diagnostic reporting functionality
+    ContextDebug(bool),
     /// Specifies which OpenGL profile to create the context for. If requesting
     /// an OpenGL version below 3.2, `OpenGlAnyProfile` must be used.
     ///
@@ -2347,10 +2361,34 @@ pub enum WindowHint {
     ///
     /// This includes the initial placement when the window is created.
     ScaleToMonitor(bool),
-    /// Specifies whether to use full resolution framebuffers on Retina displays.
+    /// Specifies whether the framebuffer should be resized based on content scale changes. This
+    /// can be because of a global user settings change or because the window was moved to a
+    /// monitor with different scale settings.
     ///
-    /// This is ignored on platforms besides macOS.
-    CocoaRetinaFramebuffer(bool),
+    /// This hint only has an effect on platforms where screen coordinates can be scaled relative
+    /// to pixel coordinates, such as macOS and Wayland. On platforms like Windows and X11 the
+    /// framebuffer and window content area sizes always map 1:1.
+    ScaleFramebuffer(bool),
+    /// Specifies whether the window is transparent to mouse input, letting any mouse events pass
+    /// through to whatever window is behind it. This is only supported for undecorated windows.
+    /// Decorated windows with this enabled will behave differently between platforms.
+    MousePassthrough(bool),
+    /// Specify the desired initial position of the window. The window manager may modify or
+    /// ignore these coordinates. If either or both of these hints are set to [`None`](Option)
+    /// then the window manager will position the window where it thinks the user will prefer it.
+    Position(Option<i32>, Option<i32>),
+    /// Specifies whether to allow access to the window menu via the Alt+Space and
+    /// Alt-and-then-Space keyboard shortcuts.
+    ///
+    /// This is ignored on other platforms
+    Win32KeyboardMenu(bool),
+    /// Specifies whether to show the window the way specified in the program's STARTUPINFO when
+    /// it is shown for the first time. This is the same information as the Run option in the
+    /// shortcut properties window. If this information was not specified when the program was
+    /// started, GLFW behaves as if this hint was set to `false`.
+    ///
+    /// This is ignored on other platforms.
+    Win32ShowDefault(bool),
     /// Specifies the UTF-8 encoded name to use for autosaving the window frame, or if empty
     /// disables frame autosaving for the window.
     ///
@@ -2370,6 +2408,9 @@ pub enum WindowHint {
     /// This only affects systems with both integrated and discrete GPUs. This is ignored on
     /// platforms besides macOS.
     CocoaGraphicsSwitching(bool),
+    /// Specifies the Wayland app_id for a window, used by window managers to identify types of
+    /// windows.
+    WaylandAppId(Option<String>),
     /// Specifies the desired ASCII-encoded class part of the ICCCM `WM_CLASS` window property.
     X11ClassName(Option<String>),
     /// Specifies the desired ASCII-encoded instance part of the ICCCM `WM_CLASS` window property.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -862,7 +862,7 @@ pub type GLProc = ffi::GLFWglproc;
 pub type VkProc = ffi::GLFWvkproc;
 
 /// Counts for (Calling glfwInit) - (Calling glfwTerminate)
-/// It uses for "global" refference counting for Glfw.
+/// It uses for "global" reference counting for Glfw.
 static REF_COUNT_FOR_GLFW: AtomicUsize = AtomicUsize::new(0);
 
 /// A struct that represents a thread safe handle to a `Glfw`
@@ -1117,7 +1117,7 @@ impl Glfw {
         callbacks::error::set(callback);
     }
 
-    /// Unsets the monitor callback
+    /// Unsets the error callback
     pub fn unset_error_callback(&mut self) {
         callbacks::error::unset();
     }
@@ -1628,10 +1628,12 @@ impl Glfw {
     ///
     /// This function returns a Vector of names of Vulkan instance extensions
     /// required by GLFW for creating Vulkan surfaces for GLFW windows. If successful,
-    /// the list will always contains `VK_KHR_surface`, so if you don't require any
+    /// the list will always contain `VK_KHR_surface`, so if you don't require any
     /// additional extensions you can pass this list directly to the `VkInstanceCreateInfo` struct.
     ///
     /// Will return `None` if the API is unavailable.
+    ///
+    /// Wrapper for `glfwGetRequiredInstanceExtensions`
     #[cfg(feature = "vulkan")]
     pub fn get_required_instance_extensions(&self) -> Option<Vec<String>> {
         let mut len: c_uint = 0;
@@ -2265,7 +2267,7 @@ pub enum WindowHint {
     /// Note that setting this to false will make `swap_buffers` do nothing useful,
     /// and your scene will have to be displayed some other way.
     DoubleBuffer(bool),
-    /// Speficies whether the cursor should be centered over newly created full screen windows.
+    /// Specifies whether the cursor should be centered over newly created full screen windows.
     ///
     /// This hint is ignored for windowed mode windows.
     CenterCursor(bool),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1697,6 +1697,20 @@ impl Glfw {
             ffi::glfwPostEmptyEvent();
         }
     }
+    /// This function returns the platform that was selected during initialization.
+    ///
+    /// Wrapper for `glfwGetPlatform`
+    pub fn get_platform(&self) -> Platform {
+        unsafe { mem::transmute(ffi::glfwGetPlatform()) }
+    }
+
+    /// This function returns whether the library was compiled with support for the specified
+    /// platform.
+    ///
+    /// Wrapper for `glfwPlatformSupported`
+    pub fn platform_supported(&self, platform: Platform) -> bool {
+        unsafe { ffi::glfwPlatformSupported(platform as c_int) == ffi::TRUE  }
+    }
 
     /// Returns the current value of the GLFW timer. Unless the timer has been
     /// set using `glfw::set_time`, the timer measures time elapsed since GLFW
@@ -2699,6 +2713,16 @@ impl Window {
     /// Wrapper for `glfwSetWindowShouldClose`.
     pub fn set_should_close(&mut self, value: bool) {
         unsafe { ffi::glfwSetWindowShouldClose(self.ptr, value as c_int) }
+    }
+
+    /// This function returns the title of the window. This is
+    /// the title set previously by ['Glfw::create_window'] or [`Window::set_title`].
+    ///
+    /// Wrapper for `glfwGetWindowTitle`
+    pub fn get_title(&self) -> Option<String> {
+        unsafe {
+            string_from_nullable_c_str(ffi::glfwGetWindowTitle(self.ptr))
+        }
     }
 
     /// Sets the title of the window.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1130,6 +1130,29 @@ pub fn init_hint(hint: InitHint) {
         }
     }
 }
+
+/// This function sets the vkGetInstanceProcAddr function that GLFW will use for all Vulkan
+/// related entry point queries.
+///
+/// This feature is mostly useful on macOS, if your copy of the Vulkan loader is in a location
+/// where GLFW cannot find it through dynamic loading, or if you are still using the static
+/// library version of the loader.
+///
+/// If set to NULL, GLFW will try to load the Vulkan loader dynamically by its standard name
+/// and get this function from there. This is the default behavior.
+///
+/// The standard name of the loader is vulkan-1.dll on Windows, libvulkan.so.1 on Linux and
+/// other Unix-like systems and libvulkan.1.dylib on macOS. If your code is also loading it via
+/// these names then you probably don't need to use this function.
+///
+/// The function address you set is never reset by GLFW, but it only takes effect during
+/// initialization. Once GLFW has been initialized, any updates will be ignored until the
+/// library is terminated and initialized again.
+#[cfg(feature = "vulkan")]
+pub fn init_vulkan_loader(loader: vk::PFN_vkGetInstanceProcAddr) {
+    unsafe { ffi::glfwInitVulkanLoader(loader) }
+}
+
 /// Initializes the GLFW library. This must be called on the main platform
 /// thread.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1624,8 +1624,6 @@ impl Glfw {
         }
     }
 
-    /// Wrapper for `glfwGetRequiredInstanceExtensions`
-    ///
     /// This function returns a Vector of names of Vulkan instance extensions
     /// required by GLFW for creating Vulkan surfaces for GLFW windows. If successful,
     /// the list will always contain `VK_KHR_surface`, so if you don't require any

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,6 +690,7 @@ pub enum CursorMode {
     Normal = ffi::CURSOR_NORMAL,
     Hidden = ffi::CURSOR_HIDDEN,
     Disabled = ffi::CURSOR_DISABLED,
+    Captured = ffi::CURSOR_CAPTURED,
 }
 
 /// Standard cursors provided by GLFW

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3535,6 +3535,12 @@ impl Window {
         unsafe { ffi::glfwGetCocoaWindow(self.ptr) }
     }
 
+    /// Wrapper for `glfwGetCocoaView`
+    #[cfg(target_os = "macos")]
+    pub fn get_cocoa_view(&self) -> *mut c_void {
+        unsafe { ffi::glfwGetCocoaView(self.ptr) }
+    }
+
     /// Wrapper for `glfwGetNSGLContext`
     #[cfg(target_os = "macos")]
     pub fn get_nsgl_context(&self) -> *mut c_void {


### PR DESCRIPTION
This depends on the [glfw-sys PR](https://github.com/PistonDevelopers/glfw-sys/pull/33). There are breaking changes present, requiring a minor bump.

Breaking changes:
- Some of the `StandardCursor` variants are renamed
    - `Hand` -> `PointingHand`
    - `HResize` -> `ResizeEW`
    - `VResize` -> `ResizeNS`
- `OpenGlDebugContext` window hint renamed to `ContextDebug`
Aliases for respective GLFW fields are available in FFI.

Todo:
- [ ] GLFW custom allocator feature. I'm not too happy with my current code regarding this and have not (as of writing this) pushed those changes here. General advice around writing this feature would be appreciated.