### PR TITLE
Disable default features for glfw-sys dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56"
 bitflags = "1.0.0"
 raw-window-handle-0-5 = { package = "raw-window-handle", version = "0.5.0", optional = true }
 raw-window-handle-0-6 = { package = "raw-window-handle", version = "0.6.0", optional = true }
-glfw-sys = {version = "6.0.0", default-features = false}
+glfw-sys = {version = "6.0.0", default-features = false, features = ["native-gl", "native-egl"]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56"
 bitflags = "1.0.0"
 raw-window-handle-0-5 = { package = "raw-window-handle", version = "0.5.0", optional = true }
 raw-window-handle-0-6 = { package = "raw-window-handle", version = "0.6.0", optional = true }
-glfw-sys = "6.0.0" 
+glfw-sys = {version = "6.0.0", default-features = false}
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.1"


### PR DESCRIPTION
Disables default features for glfw-sys dependency. The necessary features are now enabled through glfw-rs.

Before this change, glfw-sys always used its default changes, causing problems on unsupported platforms (e.g., non-wayland).