### PR TITLE
Add Captured CursorMode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,6 +695,7 @@ pub struct PixelImage {
 pub enum CursorMode {
     Normal = ffi::GLFW_CURSOR_NORMAL,
     Hidden = ffi::GLFW_CURSOR_HIDDEN,
+    Captured = ffi::GLFW_CURSOR_CAPTURED,
     Disabled = ffi::GLFW_CURSOR_DISABLED,
 }
 


### PR DESCRIPTION
This PR adds `CursorMode::Captured` which can be used with `set_cursor_mode` in order to confine a cursor to the window without hiding or disabling it. This expansion now encapsulates all accepted cursor states supported by `glfwSetInputMode` with the `GLFW_CURSOR` mode set.

See: https://www.glfw.org/docs/latest/group__input.html#gaa92336e173da9c8834558b54ee80563b
