### PR TITLE
Published 0.62.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 name = "glfw"
 readme = "README.md"
 repository = "https://github.com/bjz/glfw-rs"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2021"
 rust-version = "1.56"
 
@@ -14,7 +14,7 @@ rust-version = "1.56"
 bitflags = "1.0.0"
 raw-window-handle-0-5 = { package = "raw-window-handle", version = "0.5.0", optional = true }
 raw-window-handle-0-6 = { package = "raw-window-handle", version = "0.6.0", optional = true }
-glfw-sys = {version = "7.0.0", default-features = false, features = ["native-gl", "native-egl"]}
+glfw-sys = {version = "8.0.0", default-features = false, features = ["native-gl", "native-egl"]}
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.5.1"
@@ -51,7 +51,7 @@ x11 = ["glfw-sys/x11"]
 native-handles = ["glfw-sys/native-handles"]
 src-build = ["glfw-sys/src-build"]
 prebuilt-libs = ["glfw-sys/prebuilt-libs"]
-static-link = ["glfw-sys/static-link"]
+dynamic-link = ["glfw-sys/dynamic-link"]
 raw-window-handle-v0-6 = ["dep:raw-window-handle-0-6", "native-handles"]
 raw-window-handle-v0-5 = ["dep:raw-window-handle-0-5", "native-handles"]
 serde = ["dep:serde"]


### PR DESCRIPTION
- Updated glfw-sys dependency to 8.0.0

Glfw-sys changed to static-link by default, so the feature flag "static-link" is removed and replaced with "dynamic-link".